### PR TITLE
Add 2D spectroscopic WCS to beams.fits

### DIFF
--- a/grizli/combine.py
+++ b/grizli/combine.py
@@ -17,7 +17,7 @@ from . import GRIZLI_PATH
 
 def combine_flt(files=[], output='exposures_cmb.fits', grow=1,
                 add_padding=True, pixfrac=0.5, kernel='point',
-                verbose=True, clobber=True, ds9=None):
+                verbose=True, overwrite=True, ds9=None):
     """Drizzle distorted FLT frames to an "interlaced" image
         
     Parameters
@@ -52,7 +52,7 @@ def combine_flt(files=[], output='exposures_cmb.fits', grow=1,
     verbose : bool
         Print logging information
         
-    clobber : bool
+    overwrite : bool
         Overwrite existing files
     
     Returns
@@ -217,12 +217,12 @@ def combine_flt(files=[], output='exposures_cmb.fits', grow=1,
     hdu.append(pyfits.ImageHDU(data=rms/grow**2, header=outh, name='ERR'))
     hdu.append(pyfits.ImageHDU(data=mask*1024, header=outh, name='DQ'))
     
-    pyfits.HDUList(hdu).writeto(output, clobber=clobber, output_verify='fix')
+    pyfits.HDUList(hdu).writeto(output, overwrite=overwrite, output_verify='fix')
                     
 def combine_visits_and_filters(grow=1, pixfrac=0.5, kernel='point', 
                                filters=['G102', 'G141'], skip=None,
                                split_visit=False, split_quadrants=True, 
-                               clobber=True, ds9=None, verbose=True):
+                               overwrite=True, ds9=None, verbose=True):
     """Make combined FLT files for all FLT files in the working directory separated by targname/visit/filter
     
     Parameters
@@ -259,7 +259,7 @@ def combine_visits_and_filters(grow=1, pixfrac=0.5, kernel='point',
     verbose : bool
         Print logging information
         
-    clobber : bool
+    overwrite : bool
         Overwrite existing files
     
     Returns
@@ -286,12 +286,13 @@ def combine_visits_and_filters(grow=1, pixfrac=0.5, kernel='point',
         if split_quadrants:
             combine_quadrants(files=output_list[i]['files'], output=output,
                               ref_pixel=[507,507], 
-                              pixfrac=pixfrac, kernel=kernel, clobber=clobber,
+                              pixfrac=pixfrac, kernel=kernel, 
+                              overwrite=overwrite,
                               ds9=ds9, verbose=verbose)
         else:
             combine_flt(files=output_list[i]['files'], output=output, 
                     grow=grow, ds9=ds9, verbose=verbose, 
-                    clobber=clobber, pixfrac=pixfrac, kernel=kernel)
+                    overwrite=overwrite, pixfrac=pixfrac, kernel=kernel)
 
 def get_shifts(files, ref_pixel=[507, 507]):
     """Compute relative pixel shifts based on header WCS
@@ -468,7 +469,7 @@ def split_pixel_quadrant(dx, dy, figure='quadrants.png', show=False):
             
 def combine_quadrants(files=[], output='images_cmb.fits', grow=1, 
                  pixfrac=0.5, kernel='point', ref_pixel=[507,507],
-                 ds9=None, verbose=True, clobber=True):
+                 ds9=None, verbose=True, overwrite=True):
     """Wrapper to split a list of exposures based on their shift sub-pixel quadrants
 
     Parameters are all passed directly to `~grizli.combine.combine_flt` but 
@@ -497,7 +498,7 @@ def combine_quadrants(files=[], output='images_cmb.fits', grow=1,
                                      '_q{0:d}_cmb.fits'.format(q))
         combine_flt(files=np.array(files)[out[q]], output=quad_output, 
                     grow=grow, pixfrac=pixfrac, kernel=kernel, 
-                    ds9=ds9, verbose=verbose, clobber=clobber)    
+                    ds9=ds9, verbose=verbose, overwrite=overwrite)    
 
 # Default mapping function based on PyWCS
 class SIP_WCSMap:

--- a/grizli/fake_image.py
+++ b/grizli/fake_image.py
@@ -401,4 +401,4 @@ def make_fake_image(header, output='direct.fits', background=None, exptime=1.e4,
     hdu['ERR'].data += rms
     hdu['SCI'].data = np.random.normal(size=np.array(naxis).T)*rms
     
-    hdu.writeto(output, clobber=True, output_verify='fix')
+    hdu.writeto(output, overwrite=True, output_verify='fix')

--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -941,7 +941,7 @@ class GroupFLT():
         if save:
             fig.savefig('{0}_{1:05d}.stack.png'.format(target, id))
             hdu.writeto('{0}_{1:05d}.stack.fits'.format(target, id),
-                        clobber=True)
+                        overwrite=True)
         
         return hdu, fig
     
@@ -1490,7 +1490,7 @@ class MultiBeam(GroupFitter):
         if verbose:
             print(outfile)
         
-        hdu.writeto(outfile, clobber=True)
+        hdu.writeto(outfile, overwrite=True)
     
     def load_master_fits(self, beam_file, verbose=True):
         import copy
@@ -2915,7 +2915,7 @@ class MultiBeam(GroupFitter):
                     hdu_full.append(psf[1])
                     
         if save_fits:
-            hdu_full.writeto('{0}_{1:05d}.line.fits'.format(self.group_name, self.id), clobber=True, output_verify='silentfix')
+            hdu_full.writeto('{0}_{1:05d}.line.fits'.format(self.group_name, self.id), overwrite=True, output_verify='silentfix')
         
         return hdu_full
         
@@ -3041,7 +3041,7 @@ class MultiBeam(GroupFitter):
         fig.savefig('{0}_{1:05d}.zfit.png'.format(self.group_name, self.id))
         
         #fig2.savefig('{0}_{1:05d}.zfit.2D.png'.format(self.group_name, self.id))
-        #hdu2.writeto('{0}_{1:05d}.zfit.2D.fits'.format(self.group_name, self.id), clobber=True, output_verify='silentfix')
+        #hdu2.writeto('{0}_{1:05d}.zfit.2D.fits'.format(self.group_name, self.id), overwrite=True, output_verify='silentfix')
         
         label = '# id ra dec zbest '
         data = '{0:7d} {1:.6f} {2:.6f} {3:.5f}'.format(self.id, self.ra, self.dec,

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -2113,7 +2113,8 @@ def extract(field_root='j142724+334246', maglim=[13,24], prior=None, MW_EBV=0.00
         hdu, fig = mb.drizzle_grisms_and_PAs(fcontam=0.5, flambda=False, kernel='point', size=32, zfit=pfit, diff=diff)
         fig.savefig('{0}_{1:05d}.stack.png'.format(target, id))
 
-        hdu.writeto('{0}_{1:05d}.stack.fits'.format(target, id), clobber=True)
+        hdu.writeto('{0}_{1:05d}.stack.fits'.format(target, id), 
+                    overwrite=True)
         mb.write_master_fits()
         
         if False:
@@ -2765,7 +2766,7 @@ def make_reference_wcs(info, output='mosaic_wcs-ref.fits', filters=['G800L', 'G1
         ref_hdu.data = ref_hdu.data.astype(np.int16)
         
         if output is not None:
-            ref_hdu.writeto(output, clobber=True, output_verify='fix')
+            ref_hdu.writeto(output, overwrite=True, output_verify='fix')
     
         return ref_hdu
     else:
@@ -2850,7 +2851,7 @@ def drizzle_overlaps(field_root, filters=['F098M','F105W','F110W', 'F125W','F140
         
         ref_hdu = utils.make_maximal_wcs(wfc3ir['files'], pixel_scale=scale, get_hdu=True, pad=pad_reference, verbose=True)
         
-        ref_hdu.writeto('{0}_wcs-ref.fits'.format(field_root), clobber=True,
+        ref_hdu.writeto('{0}_wcs-ref.fits'.format(field_root), overwrite=True,
                         output_verify='fix')
         
         wfc3ir['reference'] = '{0}_wcs-ref.fits'.format(field_root)

--- a/grizli/version.py
+++ b/grizli/version.py
@@ -1,2 +1,2 @@
 # git describe --tags
-__version__ = "0.12.0-6-g74b3dc7"
+__version__ = "0.12.0-9-g98b576b"


### PR DESCRIPTION
Fix for https://github.com/gbrammer/grizli/issues/35.

The linear dispersion of the 2D cutouts is now included in the extension headers in the `beams.fits` files output by `grizli.multifit.write_master_fits`.

(Also updates all `~astropy.io.fits.write_to` keywords from `clobber` to `overwrite`.)