### PR TITLE
JWST headers in preprocessing

### DIFF
--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -100,7 +100,7 @@ visit_prep_args: &prep_args
     sky_iter: 10
     iter_atol: 0.0001
     imaging_bkg_params: {bh: 256, bw: 256, fh: 3, fw: 3, pixel_scale: 0.10, get_median: False}
-    run_separate_chip_sky: True, 
+    run_separate_chip_sky: True
     fix_stars: True
     reference_catalogs: [LS_DR9, PS1, DES, DSC, SDSS, GAIA, WISE]
     outlier_threshold: 4

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -1829,7 +1829,14 @@ def preprocess(field_root='j142724+334246',  HOME_PATH='/Volumes/Pegasus/Grizli/
             imaging_visits.append(visit)
     
     # Run preprocessing in order of decreasing filter wavelength
-    filters = [v['product'].split('-')[-1] for v in visits]
+    filters = []
+    for v in visits:
+        vspl = v['product'].split('-')
+        if vspl[-1] == 'clear':
+            filters.append(vspl[-2])
+        else:
+            filters.append(vspl[-1])
+
     fwave = np.cast[float]([f.replace('f1', 'f10'). \
                               replace('f098m', 'f0980m'). \
                               replace('lp', 'w'). \


### PR DESCRIPTION
These fixes apply updates to the JWST headers to make them look like HST for AstroDrizzle, to and fro a few times where various functions need it.  This should fix https://github.com/gbrammer/grizli/issues/69.  

Basically, everything that needs to be done to the JWST images for preprocessing is done in `prep.fresh_flt_files`, which calls out to `jwst_utils.initialize_jwst_image` for JWST exposures.

This includes:

- Update headers with HST-like keywords, making copies of the original keywords
- Apply the flat-field correction with the pipeline step if necessary
- Scale by the gain if `BUNIT=DN/S` 
- Update wcs headers with the pipeline step, including making grism exposures "look like" direct exposures so that the 2D WCS gets populated
- Clip maximum DQ bits to 16 bit integers

A few other modifications include

- The hard-coded reference filenames have also been replaced with calls to the pipeline steps.
- Don't do "fix_star_centers", which was clipping out the centers of bright cluster galaxies

