### PR TITLE
Various improvements to the JWST preparation steps

### DIFF
--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -82,6 +82,7 @@ visit_prep_args: &prep_args
     align_rms_limit: 2
     align_mag_limits: [14, 24, 0.05]
     align_assume_close: False
+    align_transform: null
     align_ref_border: 100
     max_err_percentile: 99
     align_min_flux_radius: 1.

--- a/grizli/data/jwst_bp_info.yml
+++ b/grizli/data/jwst_bp_info.yml
@@ -1,0 +1,414 @@
+MIRI:
+  F1000W:
+    ab_vega: 4.905053935983853
+    eazy_fnumber: 397
+    ebv0.1: 0.0
+    photfile: jwst_miri_photom_0073.fits
+    photmjsr: 0.8495230078697205
+    pivot: 9.9471092583611
+    rectwidth: 1.8150435977353758
+  F1130W:
+    ab_vega: 5.195159820992248
+    eazy_fnumber: 398
+    ebv0.1: 0.0
+    photfile: jwst_miri_photom_0073.fits
+    photmjsr: 2.5494699478149414
+    pivot: 11.309234333432665
+    rectwidth: 0.7305097428332569
+  F1280W:
+    ab_vega: 5.440609143915109
+    eazy_fnumber: 399
+    ebv0.1: 0.0
+    photfile: jwst_miri_photom_0073.fits
+    photmjsr: 0.9969329833984375
+    pivot: 12.809358773603089
+    rectwidth: 2.460415101840471
+  F1500W:
+    ab_vega: 5.782663866689976
+    eazy_fnumber: 400
+    ebv0.1: 0.0
+    photfile: jwst_miri_photom_0073.fits
+    photmjsr: 0.8826910257339478
+    pivot: 15.048155266467099
+    rectwidth: 2.923025456772075
+  F1800W:
+    ab_vega: 6.17214348658878
+    eazy_fnumber: 401
+    ebv0.1: 0.0
+    photfile: jwst_miri_photom_0073.fits
+    photmjsr: 1.2419899702072144
+    pivot: 17.96967355627891
+    rectwidth: 2.8670426669246867
+  F2100W:
+    ab_vega: 6.474077692471623
+    eazy_fnumber: 402
+    ebv0.1: 0.0
+    photfile: jwst_miri_photom_0073.fits
+    photmjsr: 0.9672409892082214
+    pivot: 20.801389910583502
+    rectwidth: 4.583602546001584
+  F2550W:
+    ab_vega: 6.900496585427175
+    eazy_fnumber: 403
+    ebv0.1: 0.0
+    photfile: jwst_miri_photom_0073.fits
+    photmjsr: 1.9824199676513672
+    pivot: 25.22966374735404
+    rectwidth: 3.4220462555243882
+  F560W:
+    ab_vega: 3.7144754200582386
+    eazy_fnumber: 395
+    ebv0.1: 0.0
+    photfile: jwst_miri_photom_0073.fits
+    photmjsr: 1.1270099878311157
+    pivot: 5.632612445203548
+    rectwidth: 1.0065393876223423
+  F770W:
+    ab_vega: 4.329347421098616
+    eazy_fnumber: 396
+    ebv0.1: 0.0
+    photfile: jwst_miri_photom_0073.fits
+    photmjsr: 0.5927879810333252
+    pivot: 7.636411731877862
+    rectwidth: 1.9674106390415116
+NIRCAM:
+  F070W:
+    ab_vega: 0.28818353530759633
+    eazy_fnumber: 362
+    ebv0.1: -0.2135733349211823
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 4.860785484313965
+    pivot: 0.7043221966873889
+    rectwidth: 0.1326629272152203
+  F090W:
+    ab_vega: 0.5159678259126521
+    eazy_fnumber: 363
+    ebv0.1: -0.14159054258003095
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 3.3771445751190186
+    pivot: 0.9022922169659542
+    rectwidth: 0.19425846850043202
+  F115W:
+    ab_vega: 0.7759321641966053
+    eazy_fnumber: 364
+    ebv0.1: -0.09254774154653818
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 2.974543571472168
+    pivot: 1.154300926930138
+    rectwidth: 0.22460795554808455
+  F140M:
+    ab_vega: 1.1076936997365074
+    eazy_fnumber: 368
+    ebv0.1: -0.06591852926069822
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 5.300120830535889
+    pivot: 1.4053733062516323
+    rectwidth: 0.1427602182560621
+  F150W:
+    ab_vega: 1.2042573366105531
+    eazy_fnumber: 365
+    ebv0.1: -0.05999451597075152
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 2.385913372039795
+    pivot: 1.5007454908178013
+    rectwidth: 0.3198620380691303
+  F150W2:
+    ab_vega: 1.1389861533225094
+    eazy_fnumber: 367
+    ebv0.1: -0.05998038494936772
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 0.6736560463905334
+    pivot: 1.6579555105925448
+    rectwidth: 1.1789870218960645
+  F162M:
+    ab_vega: 1.356629591362868
+    eazy_fnumber: 369
+    ebv0.1: -0.05240589072005913
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 5.033522129058838
+    pivot: 1.6272458370690417
+    rectwidth: 0.16900998767070385
+  F164N:
+    ab_vega: 1.3978350945909002
+    eazy_fnumber: 372
+    ebv0.1: -0.05142571577860651
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 43.95996856689453
+    pivot: 1.6445854009565803
+    rectwidth: 0.02021855608632381
+  F182M:
+    ab_vega: 1.5613959704243334
+    eazy_fnumber: 370
+    ebv0.1: -0.043522608266899354
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 3.693331718444824
+    pivot: 1.8452206451099955
+    rectwidth: 0.23997527701141502
+  F187N:
+    ab_vega: 1.6300206793188554
+    eazy_fnumber: 373
+    ebv0.1: -0.04238517888863779
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 39.897613525390625
+    pivot: 1.8738864366894519
+    rectwidth: 0.023671972431313474
+  F200W:
+    ab_vega: 1.6736352132713173
+    eazy_fnumber: 366
+    ebv0.1: -0.039421401098098274
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 2.010988712310791
+    pivot: 1.9886478139793544
+    rectwidth: 0.45705677823975277
+  F210M:
+    ab_vega: 1.7847944448607536
+    eazy_fnumber: 371
+    ebv0.1: -0.03625306172148157
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 4.754210472106934
+    pivot: 2.095530780611204
+    rectwidth: 0.20848304161920855
+  F212N:
+    ab_vega: 1.8071256986205373
+    eazy_fnumber: 374
+    ebv0.1: -0.035574193249874715
+    photfile: jwst_nircam_photom_0089.fits
+    photmjsr: 36.208072662353516
+    pivot: 2.1211831936185708
+    rectwidth: 0.027476331379904694
+  F250M:
+    ab_vega: 2.1219355680177228
+    eazy_fnumber: 379
+    ebv0.1: -0.02851120688911921
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 1.8272408246994019
+    pivot: 2.502573180435017
+    rectwidth: 0.18028934315843068
+  F277W:
+    ab_vega: 2.2855235295973637
+    eazy_fnumber: 375
+    ebv0.1: -0.0254291201371696
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 0.5215780735015869
+    pivot: 2.7577958764384802
+    rectwidth: 0.6824481077040923
+  F300M:
+    ab_vega: 2.4574653574425733
+    eazy_fnumber: 380
+    ebv0.1: -0.02283171334543076
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 1.2490369081497192
+    pivot: 2.987323442369741
+    rectwidth: 0.31548006083109886
+  F322W2:
+    ab_vega: 2.4965382198740564
+    eazy_fnumber: 378
+    ebv0.1: -0.021707427588161264
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 0.2277407944202423
+    pivot: 3.2316879770931566
+    rectwidth: 1.3576093738362995
+  F323N:
+    ab_vega: 2.6125238981467636
+    eazy_fnumber: 387
+    ebv0.1: -0.020693799590802087
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 13.208301544189453
+    pivot: 3.2369196521406005
+    rectwidth: 0.03864357526559588
+  F335M:
+    ab_vega: 2.6861342006766717
+    eazy_fnumber: 381
+    ebv0.1: -0.019824945173819167
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 1.0946526527404785
+    pivot: 3.362287905037259
+    rectwidth: 0.3533379937327616
+  F356W:
+    ab_vega: 2.783504572129279
+    eazy_fnumber: 376
+    ebv0.1: -0.01862680380985718
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 0.4345223903656006
+    pivot: 3.568227763839694
+    rectwidth: 0.7811651476473094
+  F360M:
+    ab_vega: 2.8357500951446024
+    eazy_fnumber: 382
+    ebv0.1: -0.018159740881044502
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 0.9860653281211853
+    pivot: 3.624208265175199
+    rectwidth: 0.3703888171547362
+  F405N:
+    ab_vega: 3.087869390589371
+    eazy_fnumber: 388
+    ebv0.1: -0.015958287378913374
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 9.906220436096191
+    pivot: 4.051697263814701
+    rectwidth: 0.04577474652795823
+  F410M:
+    ab_vega: 3.0765326539571385
+    eazy_fnumber: 383
+    ebv0.1: -0.015855299940669504
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 0.9272487759590149
+    pivot: 4.082057324627222
+    rectwidth: 0.43805498106149743
+  F430M:
+    ab_vega: 3.17629307843295
+    eazy_fnumber: 384
+    ebv0.1: -0.015009494658410573
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 1.7922990322113037
+    pivot: 4.280406169822821
+    rectwidth: 0.22783766526049648
+  F444W:
+    ab_vega: 3.204274874888016
+    eazy_fnumber: 377
+    ebv0.1: -0.014679941529834619
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 0.38998839259147644
+    pivot: 4.403671097714713
+    rectwidth: 1.0314434054189994
+  F460M:
+    ab_vega: 3.3388872651384234
+    eazy_fnumber: 385
+    ebv0.1: -0.013763397699644353
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 2.2877941131591797
+    pivot: 4.626222838425127
+    rectwidth: 0.22909531022868082
+  F466N:
+    ab_vega: 3.38197467755736
+    eazy_fnumber: 389
+    ebv0.1: -0.013678324120253958
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 14.410465240478516
+    pivot: 4.65440219568314
+    rectwidth: 0.0536718016571823
+  F470N:
+    ab_vega: 3.370803904216218
+    eazy_fnumber: 390
+    ebv0.1: -0.01350829578167297
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 14.320897102355957
+    pivot: 4.707790413430345
+    rectwidth: 0.051185552861473235
+  F480M:
+    ab_vega: 3.4119414049496166
+    eazy_fnumber: 386
+    ebv0.1: -0.013189385090825546
+    photfile: jwst_nircam_photom_0095.fits
+    photmjsr: 1.6411021947860718
+    pivot: 4.815523593549772
+    rectwidth: 0.30377992522766634
+NIRISS:
+  F090W:
+    ab_vega: 0.5160765009048276
+    eazy_fnumber: 350
+    ebv0.1: -0.14170616112327308
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 0.37283509969711304
+    pivot: 0.9024675692574968
+    rectwidth: 0.18321477998393115
+  F115W:
+    ab_vega: 0.7692119567046667
+    eazy_fnumber: 351
+    ebv0.1: -0.09321755510585866
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 0.3300777077674866
+    pivot: 1.1495456463766047
+    rectwidth: 0.2500420414413561
+  F140M:
+    ab_vega: 1.1056794024337948
+    eazy_fnumber: 354
+    ebv0.1: -0.06604038131527243
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 0.7764005064964294
+    pivot: 1.4040159763708964
+    rectwidth: 0.14238440072318734
+  F150W:
+    ab_vega: 1.195187287201415
+    eazy_fnumber: 352
+    ebv0.1: -0.06048574230741759
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 0.37078890204429626
+    pivot: 1.493448043997472
+    rectwidth: 0.3162435571455304
+  F158M:
+    ab_vega: 1.2955114789815956
+    eazy_fnumber: 355
+    ebv0.1: -0.055363828059932285
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 0.6962990760803223
+    pivot: 1.5817992861266001
+    rectwidth: 0.19905971881576806
+  F200W:
+    ab_vega: 1.6766443812555791
+    eazy_fnumber: 353
+    ebv0.1: -0.039322006418050774
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 0.34278640151023865
+    pivot: 1.9929589138848633
+    rectwidth: 0.4228740040954827
+  F277W:
+    ab_vega: 2.260183782313279
+    eazy_fnumber: 356
+    ebv0.1: -0.02562535588061217
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 1.5750579833984375
+    pivot: 2.7642260137521504
+    rectwidth: 0.6926706953372831
+  F356W:
+    ab_vega: 2.781586085893478
+    eazy_fnumber: 357
+    ebv0.1: -0.018554030128368038
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 0.26499199867248535
+    pivot: 3.5930046741596118
+    rectwidth: 0.9093105011990319
+  F380M:
+    ab_vega: 2.910082828110169
+    eazy_fnumber: 359
+    ebv0.1: -0.01716860867840539
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 7.3604350090026855
+    pivot: 3.824942095736629
+    rectwidth: 0.2054154176394431
+  F430M:
+    ab_vega: 3.1657369102215145
+    eazy_fnumber: 360
+    ebv0.1: -0.015022503733125803
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 9.185256004333496
+    pivot: 4.281684172704966
+    rectwidth: 0.20135071592404016
+  F444W:
+    ab_vega: 3.2097070476573193
+    eazy_fnumber: 358
+    ebv0.1: -0.01460863884795536
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 0.2931137979030609
+    pivot: 4.427697061100139
+    rectwidth: 1.0921486602734922
+  F480M:
+    ab_vega: 3.382818572261269
+    eazy_fnumber: 361
+    ebv0.1: -0.013232763695635287
+    photfile: jwst_niriss_photom_0038.fits
+    photmjsr: 8.240961074829102
+    pivot: 4.815190220745452
+    rectwidth: 0.2966849192800114
+meta:
+  created: '2022-05-31'
+  description:
+    ab_vega: AB - Vega mag conversion
+    eazy_fnumber: Filter number in the eazy filter file
+    ebv0.1: Milky Way extinction, mag for E(B-V)=0.1, Rv=3.1
+    photfile: Photom reference file
+    photmjsr: Photometric conversion if ref files available
+    pivot: Filter pivot wavelength
+    rectwith: Filter rectangular width
+  wave_unit: micron

--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -10,7 +10,7 @@ from collections import OrderedDict
 
 import numpy as np
 
-from . import GRIZLI_PATH
+from . import GRIZLI_PATH, utils
 
 
 class aXeConf():
@@ -942,4 +942,19 @@ def load_grism_config(conf_file):
     """
     conf = aXeConf(conf_file)
     conf.get_beams()
+    
+    # hack to remove GAIN correction from niriss
+    if 'GR150' in conf_file:
+        hack_niriss = 1./1.8
+        msg = f"""
+ ! Scale NIRISS sensitivity by {hack_niriss:.3f} to hack gain correction
+ ! and match GLASS MIRAGE simulations. Sensitivity will be updated when
+ ! on-sky data available
+ """
+        utils.log_comment(utils.LOGFILE, msg, verbose=True)
+        
+        for b in conf.sens:
+            conf.sens[b]['SENSITIVITY'] *= hack_niriss
+            conf.sens[b]['ERROR'] *= hack_niriss
+            
     return conf

--- a/grizli/model.py
+++ b/grizli/model.py
@@ -1616,9 +1616,9 @@ class ImageData(object):
 
         self.wcs = None
 
-        if (instrument in ['NIRISS', 'NIRCAM']) & (~self.is_slice):
-            if process_jwst_header:
-                self.update_jwst_wcsheader(hdulist)
+        # if (instrument in ['NIRISS', 'NIRCAM']) & (~self.is_slice):
+        #     if process_jwst_header:
+        #         self.update_jwst_wcsheader(hdulist)
 
         if self.header is not None:
             if wcs is None:

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -2668,7 +2668,7 @@ def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='.
     # Link minimal files to Extractions directory
     os.chdir(EXTRACT_PATH)
     os.system(f'ln -s {PREP_PATH}/*GrismFLT* .')
-    os.system(f'ln -s {PREP_PATH}/*_fl*wcs.fits .')
+    os.system(f'ln -s {PREP_PATH}/*.0?.wcs.fits .')
     os.system(f'ln -s {PREP_PATH}/{field_root}-*.cat.fits .')
     os.system(f'ln -s {PREP_PATH}/{field_root}-*seg.fits .')
     os.system(f'ln -s {PREP_PATH}/*_phot.fits .')

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -5681,8 +5681,13 @@ def drizzle_overlaps(exposure_groups, parse_visits=False, check_overlaps=True, m
                      resetbits=resetbits,
                      static=(static & (len(inst_keys) == 1)),
                      gain=gain, rdnoise=rdnoise)
-
+        
         clean_drizzle(group['product'], fix_wcs_system=fix_wcs_system)
+        
+        # Reset JWST headers
+        if isJWST:
+            for file in group['files']:
+                _ = jwst_utils.set_jwst_to_hst_keywords(file, reset=True)
 
 
 def manual_alignment(visit, ds9, reference=None, reference_catalogs=['SDSS', 'PS1', 'GAIA', 'WISE'], use_drz=False):

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -604,8 +604,8 @@ def match_lists(input, output, transform=None, scl=3600., simple=True,
         Output pixel/array coordinates
     
     transform : None, `skimage.transform` object
-        Coordinate transformation model.  If None, use S
-        `skimage.transform.SimilarityTransform`, i.e., (shift, scale, rot)
+        Coordinate transformation model.  If None, use
+        `skimage.transform.EuclideanTransform`, i.e., shift & rotation
     
     scl : float
         Not used
@@ -659,7 +659,7 @@ def match_lists(input, output, transform=None, scl=3600., simple=True,
     """)
 
     if transform is None:
-        transform = skimage.transform.SimilarityTransform
+        transform = skimage.transform.EuclideanTransform
 
     # print 'xyxymatch'
     if (len(output) == 0) | (len(input) == 0):
@@ -765,7 +765,8 @@ def align_drizzled_image(root='',
                          min_flux_radius=1.,
                          match_catalog_density=None,
                          assume_close=False,
-                         ref_border=100):
+                         ref_border=100, 
+                         transform=None):
     """Pipeline for astrometric alignment of drizzled image products
     
     1. Generate source catalog from image mosaics
@@ -847,6 +848,9 @@ def align_drizzled_image(root='',
         Only include reference sources within `ref_border` pixels of the 
         target image, as calculated from the original image WCS
     
+    transform : None, `skimage.transform` object
+            Coordinate transformation model.  If None, use
+            `skimage.transform.EuclideanTransform`, i.e., shift & rotation
     Returns
     -------
     orig_wcs : `~astropy.wcs.WCS`
@@ -1028,11 +1032,14 @@ def align_drizzled_image(root='',
         titer = 0
         while (titer < 3):
             try:
-                res = match_lists(output, input, scl=1., simple=simple,
-                          outlier_threshold=outlier_threshold, toler=toler,
-                          triangle_size_limit=triangle_size_limit,
-                          triangle_ba_max=triangle_ba_max,
-                          assume_close=assume_close)
+                res = match_lists(output, input, scl=1.,
+                                  simple=simple,
+                                  outlier_threshold=outlier_threshold,
+                                  toler=toler,
+                                  triangle_size_limit=triangle_size_limit,
+                                  triangle_ba_max=triangle_ba_max,
+                                  assume_close=assume_close,
+                                  transform=transform)
 
                 output_ix, input_ix, outliers, tf = res
                 break
@@ -1047,12 +1054,14 @@ def align_drizzled_image(root='',
             titer += 1
             toler += 5
             try:
-                res = match_lists(output, input, scl=1., simple=simple,
-                              outlier_threshold=outlier_threshold,
-                              toler=toler,
-                              triangle_size_limit=triangle_size_limit,
-                              triangle_ba_max=triangle_ba_max,
-                              assume_close=assume_close)
+                res = match_lists(output, input, scl=1.,
+                                  simple=simple,
+                                  outlier_threshold=outlier_threshold,
+                                  toler=toler,
+                                  triangle_size_limit=triangle_size_limit,
+                                  triangle_ba_max=triangle_ba_max,
+                                  assume_close=assume_close,
+                                  transform=transform)
             except:
                 pass
 
@@ -1076,25 +1085,32 @@ def align_drizzled_image(root='',
                               outlier_threshold=outlier_threshold,
                               toler=toler,
                               triangle_size_limit=triangle_size_limit,
-                              triangle_ba_max=triangle_ba_max)
+                              triangle_ba_max=triangle_ba_max,
+                              transform=transform)
 
             output_ix2, input_ix2, outliers2, tf = res2
 
         # Log
         shift = tf.translation
+        if hasattr(tf, 'scale'):
+            _tfscale = tf.scale
+        else:
+            _tfscale = 1.0
+        
         NGOOD = (~outliers).sum()
         logstr = '# wcs {0} ({1:d}) {2:d}: {3:6.2f} {4:6.2f} {5:7.3f} {6:7.3f}'
         logstr = logstr.format(root, iter, NGOOD, shift[0], shift[1],
-                               tf.rotation/np.pi*180, 1./tf.scale)
+                               tf.rotation/np.pi*180, 1./_tfscale)
 
         utils.log_comment(utils.LOGFILE, logstr, verbose=verbose)
 
         out_shift += tf.translation
+            
         out_rot -= tf.rotation
-        out_scale *= tf.scale
+        out_scale *= _tfscale
 
         drz_wcs = utils.transform_wcs(drz_wcs, tf.translation, tf.rotation,
-                                      tf.scale)
+                                      _tfscale)
 
         # drz_wcs.wcs.crpix += tf.translation
         # theta = -tf.rotation
@@ -1916,11 +1932,11 @@ def make_SEP_catalog(root='',
     # Info
     tab.meta['ZP'] = (ZP, 'AB zeropoint')
     if 'PHOTPLAM' in im[0].header:
-        tab.meta['PLAM'] = (im[0].header['PHOTPLAM'], 'AB zeropoint')
+        tab.meta['PLAM'] = (im[0].header['PHOTPLAM'], 'Filter pivot wave')
         if 'PHOTFNU' in im[0].header:
-            tab.meta['FNU'] = (im[0].header['PHOTFNU'], 'AB zeropoint')
+            tab.meta['FNU'] = (im[0].header['PHOTFNU'], 'Scale to Jy')
 
-        tab.meta['FLAM'] = (im[0].header['PHOTFLAM'], 'AB zeropoint')
+        tab.meta['FLAM'] = (im[0].header['PHOTFLAM'], 'Scale to flam')
 
     tab.meta['uJy2dn'] = (uJy_to_dn, 'Convert uJy fluxes to image DN')
 
@@ -2541,22 +2557,24 @@ def make_drz_catalog(root='', sexpath='sex', threshold=2., get_background=True,
 
     im = pyfits.open(drz_file)
 
-    if 'PHOTFNU' in im[0].header:
-        ZP = -2.5*np.log10(im[0].header['PHOTFNU'])+8.90
-    elif 'PHOTFLAM' in im[0].header:
-        ZP = (-2.5*np.log10(im[0].header['PHOTFLAM']) - 21.10 -
-                 5*np.log10(im[0].header['PHOTPLAM']) + 18.6921)
-    elif 'FILTER' in im[0].header:
-        fi = im[0].header['FILTER'].upper()
-        if fi in model.photflam_list:
-            ZP = (-2.5*np.log10(model.photflam_list[fi]) - 21.10 -
-                     5*np.log10(model.photplam_list[fi]) + 18.6921)
-        else:
-            print('Couldn\'t find PHOTFNU or PHOTPLAM/PHOTFLAM keywords, use ZP=25')
-            ZP = 25
-    else:
-        print('Couldn\'t find FILTER, PHOTFNU or PHOTPLAM/PHOTFLAM keywords, use ZP=25')
-        ZP = 25
+    ZP = calc_header_zeropoint(im[0].header)
+    
+    # if 'PHOTFNU' in im[0].header:
+    #     ZP = -2.5*np.log10(im[0].header['PHOTFNU'])+8.90
+    # elif 'PHOTFLAM' in im[0].header:
+    #     ZP = (-2.5*np.log10(im[0].header['PHOTFLAM']) - 21.10 -
+    #              5*np.log10(im[0].header['PHOTPLAM']) + 18.6921)
+    # elif 'FILTER' in im[0].header:
+    #     fi = im[0].header['FILTER'].upper()
+    #     if fi in model.photflam_list:
+    #         ZP = (-2.5*np.log10(model.photflam_list[fi]) - 21.10 -
+    #                  5*np.log10(model.photplam_list[fi]) + 18.6921)
+    #     else:
+    #         print('Couldn\'t find PHOTFNU or PHOTPLAM/PHOTFLAM keywords, use ZP=25')
+    #         ZP = 25
+    # else:
+    #     print('Couldn\'t find FILTER, PHOTFNU or PHOTPLAM/PHOTFLAM keywords, use ZP=25')
+    #     ZP = 25
 
     if verbose:
         print('Image AB zeropoint: {0:.3f}'.format(ZP))
@@ -3095,6 +3113,7 @@ def process_direct_grism_visit(direct={},
                                align_ref_border=100,
                                align_min_flux_radius=1., 
                                align_assume_close=False,
+                               align_transform=None,
                                max_err_percentile=99,
                                catalog_mask_pad=0.05,
                                match_catalog_density=None,
@@ -3413,7 +3432,8 @@ def process_direct_grism_visit(direct={},
                                 match_catalog_density=match_catalog_density,
                                       ref_border=align_ref_border, 
                                       min_flux_radius=align_min_flux_radius, 
-                                      assume_close=align_assume_close)
+                                      assume_close=align_assume_close,
+                                      transform=align_transform)
         except:
 
             utils.log_exception(utils.LOGFILE, traceback)
@@ -3435,7 +3455,8 @@ def process_direct_grism_visit(direct={},
                                       catalog_mask_pad=catalog_mask_pad,
                                 match_catalog_density=match_catalog_density,
                                       ref_border=align_ref_border,
-                                      min_flux_radius=align_min_flux_radius)
+                                      min_flux_radius=align_min_flux_radius,
+                                      transform=align_transform)
 
         orig_wcs, drz_wcs, out_shift, out_rot, out_scale = result
 
@@ -4807,8 +4828,7 @@ def visit_grism_sky(grism={}, apply=True, column_average=True, verbose=True, ext
         rot90 = grismconf.JwstDispersionTransform(header=flt[0].header).rot90
         if rot90 % 2 == 0:
             avg_axis = 0
-            col_text = 'column'
-            
+            col_label = 'column'
         else:
             avg_axis = 1
             col_label = 'row'

--- a/grizli/tests/test_jwst.py
+++ b/grizli/tests/test_jwst.py
@@ -4,9 +4,32 @@ Tests for JWST imaging and spectra, including
 import os
 import glob
 import unittest
+import numpy as np
 
-from .. import utils, multifit, GRIZLI_PATH
+from .. import utils, multifit, GRIZLI_PATH, jwst_utils
 from ..pipeline import auto_script
+
+class JWSTUtils(unittest.TestCase):
+    
+    def test_filter_info(self):
+        """
+        Read the info file and get filter data
+        """
+        import astropy.io.fits as pyfits
+        
+        bp = jwst_utils.load_jwst_filter_info()
+        assert('meta' in bp)
+
+        header = pyfits.Header()
+        header['TELESCOP'] = 'JWST'
+        header['INSTRUME'] = 'NIRCAM'
+        header['FILTER'] = 'F200W'
+        header['PUPIL'] = 'CLEAR'
+        
+        info = jwst_utils.get_jwst_filter_info(header)
+        
+        assert(info['name'] == 'F200W')
+        assert(np.allclose(info['pivot'], 1.988647))
 
 
 class JWSTFittingTools(unittest.TestCase):


### PR DESCRIPTION
This PR implements a number of improvements to the preparation pipeline of JWST images.

1) It provides better handling of `rate` and `cal` FITS products, updating header keywords throughout with the appropriate photometric conversion factors without modifying the data values directly.  There is now a full table of information for all imaging filters in NIRISS, NIRCAM and MIRI, with pivot wavelengths and guesses of the photometric scaling factors extracted from a recent version of the `photom` reference files.
    - The filter information is retrieved with `get_jwst_filter_info`
    - The photometric keywords are calculated in the function `get_phot_keywords`
     - the Gain correction is removed from the jwst initialization function as it doesn't seem to be applied by the Image2 pipeline itself.
 
2) An improved function `pipeline_model_wcs_header` for deriving a FITS-SIP header from the `gwcs` object populated by the `assign_wcs` step.  This function fits increasingly high order SIP models and stops when a desired tolerance is reached.  The pixel offsets w.r.t. the `gwcs` headers are < 0.001 pix for 1 NIRISS, 2 NIRCam and 1 MIRI filters tested, and the MIRI correspondence is essentially limited by numerical precision.  
    - This appears to be more robust than the prepackeged `datamodel.meta.wcs.to_fits_sip` method, though it's still a bit unstable in that the quality of the fits can change a lot with small changes to the `LSQ_ARGS` parameters for the optimization
    - Still under development is a function `match_gwcs_to_sip` for a reverse transformation updating the keywords that determine the `gwcs` solution based the transformations that (may have) been applied to the SIP / CD keywords.  The function appears to work well, but it's not yet incorporated into the prep pipeline.