### PR TITLE
Rename get_hst_filter to parse_filter_from_header, include NIRCam detectors in visit parsing

### DIFF
--- a/grizli/aws/aws_drizzler.py
+++ b/grizli/aws/aws_drizzler.py
@@ -918,7 +918,7 @@ def drizzle_images(label='macs0647-jd1', ra=101.9822125, dec=70.24326667, pixsca
 
                 filt_i = file.split('-')[-1].split('_dr')[0]
             else:
-                filt_i = utils.get_hst_filter(hdu_i[0].header)
+                filt_i = utils.parse_filter_from_header(hdu_i[0].header)
 
             for h in hdu_i:
                 h.header['EXTVER'] = filt_i
@@ -1122,14 +1122,14 @@ def combine_filters(label='j022708p4901_00273', verbose=True):
                     num = sci*wht[0].data
                     den = wht[0].data
                     drz_ref = drz
-                    drz_ref[0].header['CFILT{0}'.format(i+1)] = utils.get_hst_filter(drz[0].header)
+                    drz_ref[0].header['CFILT{0}'.format(i+1)] = utils.parse_filter_from_header(drz[0].header)
                     drz_ref[0].header['NCOMBINE'] = (len(drz_files), 'Number of combined filters')
                 else:
                     scl = drz[0].header['PHOTFLAM']/photflam
                     num += sci*scl*(wht[0].data/scl**2)
                     den += wht[0].data/scl**2
 
-                    drz_ref[0].header['CFILT{0}'.format(i+1)] = utils.get_hst_filter(drz[0].header)
+                    drz_ref[0].header['CFILT{0}'.format(i+1)] = utils.parse_filter_from_header(drz[0].header)
                     drz_ref[0].header['NDRIZIM'] += drz[0].header['NDRIZIM']
 
             sci = num/den

--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -136,7 +136,7 @@ def s3_put_exposure(flt_file, product, assoc, remove_old=True, verbose=True):
         expflag, sunangle = None, None
         
     else:
-        filt = utils.get_hst_filter(h0)
+        filt = utils.parse_filter_from_header(h0)
         pupil = ''
         exptime = h0['EXPTIME']
         expflag = h0['EXPFLAG']

--- a/grizli/jwst_utils.py
+++ b/grizli/jwst_utils.py
@@ -1560,7 +1560,7 @@ def compare_gwcs_sip(file, save=False, step=32, use_gwcs_func=False, func_kwargs
     axes[0].text(0.5, 0.98, file, ha='center', va='top', 
                  transform=axes[0].transAxes, fontsize=6)
                  
-    label = f"{im[0].header['INSTRUME']} {utils.get_hst_filter(im[0].header)}"
+    label = f"{im[0].header['INSTRUME']} {utils.parse_filter_from_header(im[0].header)}"
     axes[0].text(0.5, 0.94, label, ha='center', va='top', 
                  transform=axes[0].transAxes, fontsize=8)
                  

--- a/grizli/model.py
+++ b/grizli/model.py
@@ -1441,7 +1441,7 @@ class ImageData(object):
                 raise KeyError(msg)
 
             instrument = h['INSTRUME']
-            filter = utils.get_hst_filter(h, filter_only=True)
+            filter = utils.parse_filter_from_header(h, filter_only=True)
 
             if 'PUPIL' in h:
                 pupil = h['PUPIL']
@@ -2616,7 +2616,7 @@ class GrismFLT(object):
                                       segmentation=False, interp='poly5')
 
         header_values = {}
-        self.direct.ref_filter = utils.get_hst_filter(refh)
+        self.direct.ref_filter = utils.parse_filter_from_header(refh)
         self.direct.ref_file = ref_str
 
         key_list = {'PHOTFLAM': photflam_list, 'PHOTPLAM': photplam_list}

--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -1301,7 +1301,7 @@ class GroupFLT():
 #             for k in ['PHOTFLAM', 'PHOTPLAM']:
 #                 ext.header[k] = ref_im[0].header[k]
 #
-#             the_filter = utils.get_hst_filter(ref_im[0].header)
+#             the_filter = utils.parse_filter_from_header(ref_im[0].header)
 #             ext.header['FILTER'] = ext.header['DFILTER'] = the_filter
 #
 #             wcs_file = ext.header['GPARENT'].replace('.fits', '.{0:02}.wcs.fits'.format(ext.header['SCI_EXTN']))
@@ -1941,7 +1941,7 @@ class MultiBeam(GroupFitter):
             ref_photflam = 1.
 
         try:
-            ref_filter = utils.get_hst_filter(ref_header)
+            ref_filter = utils.parse_filter_from_header(ref_header)
         except:
             ref_filter = 'N/A'
 

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -1415,7 +1415,7 @@ def parse_visits(files=[], field_root='', RAW_PATH='../RAW', use_visit=True, com
             # Build from IMA filename
             root = os.path.basename(file).split("_ima")[0][:-1]
             im = pyfits.open(file)
-            filt = utils.get_hst_filter(im[0].header).lower()
+            filt = utils.parse_filter_from_header(im[0].header).lower()
             wcs = pywcs.WCS(im['SCI'].header)
             fp = Polygon(wcs.calc_footprint())
 

--- a/grizli/tests/test_jwst.py
+++ b/grizli/tests/test_jwst.py
@@ -120,8 +120,9 @@ class JWSTUtils(unittest.TestCase):
         header['INSTRUME'] = 'NIRISS'
         header['PUPIL'] = 'F200W'
         header['FILTER'] = 'CLEAR'
+        header['DETECTOR'] = 'NIS'
         
-        assert(utils.get_hst_filter(header) == 'F200W-CLEAR')
+        assert(utils.parse_filter_from_header(header) == 'F200W-CLEAR')
                 
         info = jwst_utils.get_jwst_filter_info(header)
         
@@ -134,8 +135,9 @@ class JWSTUtils(unittest.TestCase):
         header['INSTRUME'] = 'NIRCAM'
         header['FILTER'] = 'F200W'
         header['PUPIL'] = 'CLEAR'
+        header['DETECTOR'] = 'NRCA1'
         
-        assert(utils.get_hst_filter(header) == 'F200W-CLEAR')
+        assert(utils.parse_filter_from_header(header) == 'F200W-CLEAR')
                 
         info = jwst_utils.get_jwst_filter_info(header)
         
@@ -148,7 +150,7 @@ class JWSTUtils(unittest.TestCase):
         header['INSTRUME'] = 'MIRI'
         header['FILTER'] = 'F560W'
         
-        assert(utils.get_hst_filter(header) == 'F560W')
+        assert(utils.parse_filter_from_header(header) == 'F560W')
         
         info = jwst_utils.get_jwst_filter_info(header)
         assert(info['name'] == 'F560W')


### PR DESCRIPTION
Rename the function `utils.get_hst_filter` to `utils.parse_filter_from_header` throughout, since it parses headers from other telescopes.  

That new function includes a keyword argument `jwst_detector=False` that prepends the JWST detector to the filter string, which is useful mostly for making unique visit product names in `utils.get_flt_info` and `utils.parse_flt_files`.  

**Note:** The detector name is extracted from the ``DETECTOR`` keyword, but in NIRCam the LW detector name is changed from "LONG" to "5", e.g., "nrca5", to better match the FITS filenames.

So, product names are something like ``unknown-02561-001-036.0-nrcb1-f115w-clear`` and ``unknown-02561-001-036.0-nrcb5-f277w-clear``.

This PR also fixes a bug where the JWST header keywords were being set extra times before passing to drizzle.