### PR TITLE
Add `sip_rot90` function

### DIFF
--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -478,7 +478,7 @@ class GroupFLT():
         if verbose:
             print('Now we have {0:d} FLTs'.format(self.N))
 
-    def compute_single_model(self, id, center_rd=None, mag=-99, size=-1, store=False, spectrum_1d=None, is_cgs=False, get_beams=None, in_place=True, psf_param_dict={}):
+    def compute_single_model(self, id, center_rd=None, mag=-99, size=-1, store=False, spectrum_1d=None, is_cgs=False, get_beams=None, in_place=True, min_size=26, psf_param_dict={}):
         """Compute model spectrum in all exposures
         TBD
 
@@ -522,7 +522,8 @@ class GroupFLT():
                           size=size, compute_size=(size < 0),
                           mag=mag, in_place=in_place, store=store,
                           spectrum_1d=spectrum_1d, is_cgs=is_cgs,
-                          get_beams=get_beams, psf_params=psf_params)
+                          get_beams=get_beams, psf_params=psf_params,
+                          min_size=min_size)
 
             out_beams.append(status)
 
@@ -655,7 +656,11 @@ class GroupFLT():
             List of `~grizli.model.BeamCutout` objects.
 
         """
-        beams = self.compute_single_model(id, center_rd=center_rd, size=size, store=False, get_beams=[beam_id])
+        beams = self.compute_single_model(id,
+                                         center_rd=center_rd,
+                                         size=size,
+                                         store=False,
+                                         get_beams=[beam_id])
 
         out_beams = []
         for flt, beam in zip(self.FLTs, beams):

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -2532,6 +2532,20 @@ def load_GroupFLT(field_root='j142724+334246', PREP_PATH='../Prep', force_ref=No
                           gr, filt]
     
     # NIRCam
+    # has_nircam = False
+    # for filt in ['F277W', 'F356W', 'F410M', 'F444W']:
+    #     for ig, gr in enumerate(['GRISMR','GRISMC']):
+    #         #key = f'{gr.lower()}-{filt.lower()}'
+    #         key = f'nircam-{filt.lower()}'
+    #         if ig == 0:
+    #             masks[key] = [((info['PUPIL'] == filt) & 
+    #                            (info['FILTER'] == gr)), gr, filt]
+    #         else:
+    #             masks[key][0] != ((info['PUPIL'] == filt) &
+    #                               (info['FILTER'] == gr))
+    #                               
+    #         has_nircam |= masks[key][0].sum() > 0
+    
     has_nircam = False
     for gr in ['GRISMR','GRISMC']:
         for filt in ['F277W', 'F356W', 'F410M', 'F444W']:
@@ -2610,7 +2624,7 @@ def load_GroupFLT(field_root='j142724+334246', PREP_PATH='../Prep', force_ref=No
         return [grp]
 
 
-def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='../Extractions', ds9=None, refine_niter=3, gris_ref_filters=GRIS_REF_FILTERS, files=None, split_by_grism=True, refine_poly_order=1, refine_fcontam=0.5, cpu_count=0, mask_mosaic_edges=True, prelim_mag_limit=25, refine_mag_limits=[18, 24], init_coeffs=[1.1, -0.5], grisms_to_process=None, pad=256):
+def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='../Extractions', ds9=None, refine_niter=3, gris_ref_filters=GRIS_REF_FILTERS, files=None, split_by_grism=True, refine_poly_order=1, refine_fcontam=0.5, cpu_count=0, mask_mosaic_edges=True, prelim_mag_limit=25, refine_mag_limits=[18, 24], init_coeffs=[1.1, -0.5], grisms_to_process=None, pad=256, model_kwargs={'compute_size': True}):
     """
     Contamination model for grism exposures
     """
@@ -2645,7 +2659,8 @@ def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='.
         # Compute preliminary model
         grp.compute_full_model(fit_info=None, verbose=True, store=False, 
                                mag_limit=prelim_mag_limit, coeffs=init_coeffs, 
-                               cpu_count=cpu_count)
+                               cpu_count=cpu_count,
+                               model_kwargs=model_kwargs)
 
         ##############
         # Save model to avoid having to recompute it again

--- a/grizli/tests/test_utils.py
+++ b/grizli/tests/test_utils.py
@@ -124,4 +124,125 @@ class UtilsTester(unittest.TestCase):
                 assert(np.allclose(un.array[un[v]], v))
                 assert(np.allclose(un[v], vs))
                 assert(np.allclose(un.array[vs], v))
+    
+    
+    def test_sip_rot90(self):
+        """
+        Test functions to rotate a SIP FITS WCS/Header by steps of 90 degrees
+        """
+        import astropy.wcs
+        import astropy.io.fits
+        import matplotlib.pyplot as plt
         
+        # NIRCam header
+        hdict = {'WCSAXES': 2,
+         'CRPIX1': 1023.898,
+         'CRPIX2': 1024.804,
+         'CD1_1': 1.1134906417684e-05,
+         'CD1_2': 1.3467824656321e-05,
+         'CD2_1': 1.3420087352956e-05,
+         'CD2_2': -1.1207451566394e-05,
+         'CDELT1': 1.0,
+         'CDELT2': 1.0,
+         'CUNIT1': 'deg',
+         'CUNIT2': 'deg',
+         'CTYPE1': 'RA---TAN-SIP',
+         'CTYPE2': 'DEC--TAN-SIP',
+         'CRVAL1': 214.96738973536,
+         'CRVAL2': 52.90902634452,
+         'LONPOLE': 180.0,
+         'LATPOLE': 52.90902634452,
+         'MJDREF': 0.0,
+         'RADESYS': 'ICRS',
+         'A_ORDER': 5,
+         'A_0_2': -1.5484928795603e-06,
+         'A_0_3': -8.2999183617139e-12,
+         'A_0_4': -5.7190213371208e-15,
+         'A_0_5': 4.07621451394597e-18,
+         'A_1_1': -1.1539811084739e-05,
+         'A_1_2': 1.5338981510392e-09,
+         'A_1_3': -5.0844995554426e-14,
+         'A_1_4': 7.75217206451159e-17,
+         'A_2_0': 1.90893037341374e-06,
+         'A_2_1': -9.4268503941122e-11,
+         'A_2_2': 3.36511405738904e-15,
+         'A_2_3': 1.01913003404162e-17,
+         'A_3_0': 1.43597235355948e-09,
+         'A_3_1': -4.6987250431983e-14,
+         'A_3_2': 1.57099611614835e-16,
+         'A_4_0': 1.02466627979516e-14,
+         'A_4_1': 8.67685711756312e-18,
+         'A_5_0': 8.38989007060477e-17,
+         'B_ORDER': 5,
+         'B_0_2': -6.7240563576112e-06,
+         'B_0_3': 1.56045160756803e-09,
+         'B_0_4': -3.1953236128479e-14,
+         'B_0_5': 6.10311418213124e-17,
+         'B_1_1': 3.60929897034643e-06,
+         'B_1_2': -1.0268629323178e-10,
+         'B_1_3': 1.71406384407525e-14,
+         'B_1_4': 8.84616612338102e-18,
+         'B_2_0': 4.89531710581344e-06,
+         'B_2_1': 1.39303581747843e-09,
+         'B_2_2': -8.0509590680251e-15,
+         'B_2_3': 1.49127030961831e-16,
+         'B_3_0': -1.337273982495e-11,
+         'B_3_1': 1.81206781900953e-14,
+         'B_3_2': 1.17056127262783e-17,
+         'B_4_0': 2.30644152575784e-14,
+         'B_4_1': 8.12712563368295e-17,
+         'B_5_0': 4.96075368013397e-18,
+         'NAXIS': 2,
+         'NAXIS1': 2048,
+         'NAXIS2': 2048}
+
+        h = astropy.io.fits.Header()
+        for k in hdict:
+            h[k] = hdict[k]
+
+        wcs = astropy.wcs.WCS(h, relax=True)
+
+        for rot in range(-5,6):
+            _ = utils.sip_rot90(wcs, rot, compare=False, verbose=False)
+
+        orig = utils.to_header(wcs)
+
+        xp = [356, 1024]
+
+        # Rotate 90 degrees twice
+        new, new_wcs, desc = utils.sip_rot90(orig, 1,
+                                             compare=False, verbose=False)
+        new2, new2_wcs, desc2 = utils.sip_rot90(new, 1,
+                                             compare=False, verbose=False)
+
+        # Rotate 180
+        new2b, new2b_wcs, desc2b = utils.sip_rot90(orig, 2,
+                                             compare=False, verbose=False)
+
+        # Test coordinates
+        rd = wcs.all_pix2world(np.atleast_2d(xp), 1)
+        rd1 = new_wcs.all_pix2world(np.atleast_2d([xp[1], 2048-xp[0]]), 1)
+        assert(np.allclose(rd, rd1))
+
+        rd2 = new2b_wcs.all_pix2world(2048-np.atleast_2d(xp), 1)
+        assert(np.allclose(rd, rd2))
+
+        # Back to start
+        newx, newx_wcs, descx = utils.sip_rot90(new2b, 2,
+                                                compare=False, verbose=False)
+
+        for i in range(new['A_ORDER']+1):
+            for j in range(new['B_ORDER']+1):
+                Aij  = f'A_{i}_{j}'
+                Bij  = f'B_{i}_{j}'
+                if Aij not in new:
+                    continue
+
+                assert(np.allclose(new2[Aij], new2b[Aij]))
+                assert(np.allclose(new2[Bij], new2b[Bij]))
+                assert(np.allclose(newx[Aij], orig[Aij]))
+                assert(np.allclose(newx[Bij], orig[Bij]))
+
+        print('sip_rot90 tests passed')
+        
+        plt.close('all')

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -4092,6 +4092,7 @@ def sip_rot90(input, rot, reverse=False, verbose=False, compare=False):
     import copy
     import astropy.io.fits
     import astropy.wcs
+    import matplotlib.pyplot as plt
     
     if isinstance(input, astropy.io.fits.Header):
         orig = copy.deepcopy(input)

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -4058,6 +4058,183 @@ def transform_wcs(in_wcs, translation=[0., 0.], rotation=0., scale=1.):
     return out_wcs
 
 
+def sip_rot90(input, rot, reverse=False, verbose=False, compare=False):
+    """
+    Rotate a SIP WCS by increments of 90 degrees using direct transformations
+    between x / y coordinates
+    
+    Parameters
+    ----------
+    input : `~astropy.io.fits.Header` or `~astropy.wcs.WCS`
+        Header or WCS
+    
+    rot : int
+        Number of times to rotate the WCS 90 degrees *clockwise*, analogous
+        to `numpy.rot90`
+    
+    reverse : bool
+        If `input` is a header and includes a keyword ``ROT90``, then undo 
+        the rotation and remove the keyword from the output header
+        
+    Returns
+    -------
+    header : `~astropy.io.fits.Header`
+        Rotated WCS header
+        
+    wcs : `~astropy.wcs.WCS`
+        Rotated WCS
+    
+    desc : str
+        Description of the transform associated with ``rot``, e.g, 
+        ``x=nx-x, y=ny-y`` for ``rot=±2``.
+        
+    """
+    import copy
+    import astropy.io.fits
+    import astropy.wcs
+    
+    if isinstance(input, astropy.io.fits.Header):
+        orig = copy.deepcopy(input)
+        new = copy.deepcopy(input)
+        
+        if ('ROT90' in input):
+            if reverse:
+                rot = -orig['ROT90']
+                new.remove('ROT90')
+            else:
+                new['ROT90'] = orig['ROT90'] + rot
+        else:
+            new['ROT90'] = rot
+    else:
+        orig = to_header(input)
+        new = to_header(input)
+
+    orig_wcs = pywcs.WCS(orig, relax=True)
+
+    ### CD = [[dra/dx, dra/dy], [dde/dx, dde/dy]]
+    ### x = a_i_j * u**i * v**j
+    ### y = b_i_j * u**i * v**j
+    
+    ix = 1
+    
+    if compare:
+        xarr = np.arange(0,2048,64)
+        xp, yp = np.meshgrid(xarr, xarr)
+        rd = orig_wcs.all_pix2world(xp, yp, ix)
+
+    if rot % 4 == 1:
+        # CW 90 deg : x = y, y = (nx - x), u=v, v=-u
+        desc = 'x=y, y=nx-x'
+        
+        new['CRPIX1'] = orig['CRPIX2']
+        new['CRPIX2'] = orig['NAXIS1'] - orig['CRPIX1'] + 1
+
+        new['CD1_1'] = orig['CD1_2']
+        new['CD1_2'] = -orig['CD1_1']
+        new['CD2_1'] = orig['CD2_2']
+        new['CD2_2'] = -orig['CD2_1']
+
+        for i in range(new['A_ORDER']+1):
+            for j in range(new['B_ORDER']+1):
+                Aij  = f'A_{i}_{j}'
+                if Aij not in new:
+                    continue
+
+                new[f'A_{i}_{j}'] = orig[f'B_{j}_{i}']*(-1)**j
+                new[f'B_{i}_{j}'] = orig[f'A_{j}_{i}']*(-1)**j*-1
+
+        new_wcs = astropy.wcs.WCS(new, relax=True)
+        
+        if compare:
+            xr, yr = new_wcs.all_world2pix(*rd, ix)
+            xo = yp
+            yo = orig['NAXIS1'] - xp
+
+    elif rot % 4 == 3:
+        # CW 270 deg : y = x, x = (ny - u), u=-v, v=u
+        desc = 'x=ny-y, y=x'
+
+        new['CRPIX1'] = orig['NAXIS2'] - orig['CRPIX2'] + 1
+        new['CRPIX2'] = orig['CRPIX1']
+
+        new['CD1_1'] = -orig['CD1_2']
+        new['CD1_2'] = orig['CD1_1']
+        new['CD2_1'] = -orig['CD2_2']
+        new['CD2_2'] = orig['CD2_1']
+
+        for i in range(new['A_ORDER']+1):
+            for j in range(new['B_ORDER']+1):
+                Aij  = f'A_{i}_{j}'
+                if Aij not in new:
+                    continue
+
+                new[f'A_{i}_{j}'] = orig[f'B_{j}_{i}']*(-1)**i*-1
+                new[f'B_{i}_{j}'] = orig[f'A_{j}_{i}']*(-1)**i
+
+        new_wcs = astropy.wcs.WCS(new, relax=True)
+        
+        if compare:
+            xr, yr = new_wcs.all_world2pix(*rd, ix)
+            xo = orig['NAXIS2'] - yp
+            yo = xp
+
+
+    elif rot % 4 == 2:
+        # CW 180 deg : x=nx-x, y=ny-y, u=-u, v=-v
+        desc = 'x=nx-x, y=ny-y'
+
+        new['CRPIX1'] = orig['NAXIS1'] - orig['CRPIX1'] + 1
+        new['CRPIX2'] = orig['NAXIS2'] - orig['CRPIX2'] + 1
+
+        new['CD1_1'] = -orig['CD1_1']
+        new['CD1_2'] = -orig['CD1_2']
+        new['CD2_1'] = -orig['CD2_1']
+        new['CD2_2'] = -orig['CD2_2']
+
+        for i in range(new['A_ORDER']+1):
+            for j in range(new['B_ORDER']+1):
+                Aij  = f'A_{i}_{j}'
+                if Aij not in new:
+                    continue
+
+                new[f'A_{i}_{j}'] = orig[f'A_{i}_{j}']*(-1)**j*(-1)**i*-1
+                new[f'B_{i}_{j}'] = orig[f'B_{i}_{j}']*(-1)**j*(-1)**i*-1
+
+        new_wcs = astropy.wcs.WCS(new, relax=True)
+        
+        if compare:
+            xr, yr = new_wcs.all_world2pix(*rd, ix)
+            xo = orig['NAXIS1'] - xp
+            yo = orig['NAXIS2'] - yp
+    else:
+        # rot=0, do nothing
+        desc = 'x=x, y=y'
+        new_wcs = orig_wcs
+        if compare:
+            xo = xp
+            yo = yp
+            xr, yr = new_wcs.all_world2pix(*rd, ix)
+        
+    if verbose:
+        if compare:
+            xrms = nmad(xr-xo)
+            yrms = nmad(yr-yo)
+            print(f'Rot90: {rot} rms={xrms:.2e} {yrms:.2e}')
+            
+    if compare:
+        fig, axes = plt.subplots(1,2,figsize=(10,5), sharex=True, sharey=True)
+        axes[0].scatter(xp, xr-xo)
+        axes[0].set_xlabel('dx')
+        axes[1].scatter(yp, yr-yo)
+        axes[1].set_xlabel('dy')
+        for ax in axes:
+            ax.grid()
+        
+        fig.tight_layout(pad=0.5)
+    
+    return new, new_wcs, desc
+
+
 def get_wcs_slice_header(wcs, slx, sly):
     """TBD
     """


### PR DESCRIPTION
Add `utils.sip_rot90` function to do the full analytic 90 degree rotations of a SIP WCS header.

The SIP coefficients are swapped and modified with the following coordinate subsitutions

rot=1 (90 degrees  CW): `x=y, y=nx-x`
rot=2 (180 degrees CW): `x=nx-x, y=ny-y`
rot=3 (270 degrees CW): `x=ny-y, y=x`


