### PR TITLE
Add JWST photometry correction

### DIFF
--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -1404,7 +1404,7 @@ def res_query_from_local(files=None, filters=None):
     return res
 
 
-def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-27.7910651, size=5*60, filters=['F160W'], ir_scale=0.1, ir_wcs=None, res=None, half_optical=True, kernel='point', pixfrac=0.33, make_figure=True, skip_existing=True, clean_flt=True, gzip_output=True, s3output='s3://grizli-v2/HST/Pipeline/Mosaic/', split_uvis=True, extra_query='', extra_wfc3ir_badpix=True, fix_niriss=True, scale_nanojy=10, verbose=True, niriss_ghost_kwargs={}, **kwargs):
+def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-27.7910651, size=5*60, filters=['F160W'], ir_scale=0.1, ir_wcs=None, res=None, half_optical=True, kernel='point', pixfrac=0.33, make_figure=True, skip_existing=True, clean_flt=True, gzip_output=True, s3output='s3://grizli-v2/HST/Pipeline/Mosaic/', split_uvis=True, extra_query='', extra_wfc3ir_badpix=True, fix_niriss=True, scale_nanojy=10, verbose=True, niriss_ghost_kwargs={}, scale_photom=True, **kwargs):
     """
     Make mosaic from exposures defined in the exposure database
     
@@ -1570,6 +1570,7 @@ def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-
                                      kernel=kernel, clean=clean_flt, 
                                      extra_wfc3ir_badpix=extra_wfc3ir_badpix,
                                      verbose=verbose,
+                                     scale_photom=scale_photom,
                                      niriss_ghost_kwargs=niriss_ghost_kwargs)
                              
         outsci, outwht, header, flist, wcs_tab = _

--- a/grizli/data/photom_correction.yml
+++ b/grizli/data/photom_correction.yml
@@ -1,0 +1,101 @@
+# Inverse photometry corrections 
+# 26 August 2022
+#
+# The values below are the median ratios of the flux densities of
+# sources observed in a given detector-filter with respect to a 
+# reference.  Values > 1.0 mean that the flux density derived using 
+# the current calibrations is too bright relative to the reference.  
+#
+# The values are scalings relative to the photom calibrations for a given 
+# CRDS_CTX as indicated
+#
+# So, to apply the corrections below, *divide* the images (SCI and ERR)
+# by these values.
+#
+# For NIRISS (NIS), the reference values are the fluxes of standard 
+# stars in CAL-
+#    
+# For NIRCAM SW, the values are the ratio of the NRC to NIS fluxes for stars
+# in the astrometric calibration field.
+#
+# For NIRCAM LW, the absolute calibration in the B module comes from the
+# standard.  The relative A/B calibration of F277W, F300M, and F356W comes
+# from a field observed in COM-1063 where the pointing was shifted to cover 
+# the same piece of sky with both modules.  The relative A/B scaling from
+# 277/356 is copied to F410M and F444W.
+#
+# Context used to derive the corrections
+CRDS_CTX: jwst_0942.pmap
+
+# Max context where corrections apply
+CRDS_CTX_MAX: jwst_9999.pmap
+
+# NIS absolute derived from flux standard
+NIS-CLEAR-F090W: 1.0
+NIS-CLEAR-F115W: 1.0
+NIS-CLEAR-F150W: 1.0
+NIS-CLEAR-F200W: 1.04
+
+# All absolute NRC SW broad-band values derived relative to
+# NIS in the LMC astrometric field.  
+NRCA1-F090W-CLEAR: 1.2104
+NRCA1-F115W-CLEAR: 1.0944
+NRCA1-F150W-CLEAR: 1.0683
+NRCA1-F200W-CLEAR: 1.1555
+
+NRCA2-F090W-CLEAR: 1.2011
+NRCA2-F115W-CLEAR: 1.1008
+NRCA2-F150W-CLEAR: 1.0673
+NRCA2-F200W-CLEAR: 1.1246
+
+NRCA3-F090W-CLEAR: 1.3130
+NRCA3-F115W-CLEAR: 1.1598
+NRCA3-F150W-CLEAR: 1.1394
+NRCA3-F200W-CLEAR: 1.2506
+
+NRCA4-F090W-CLEAR: 1.3281
+NRCA4-F115W-CLEAR: 1.2294
+NRCA4-F150W-CLEAR: 1.1948
+NRCA4-F200W-CLEAR: 1.2642
+
+NRCB1-F090W-CLEAR: 1.1186
+NRCB1-F115W-CLEAR: 1.0426
+NRCB1-F150W-CLEAR: 1.0576
+NRCB1-F200W-CLEAR: 1.1453
+
+NRCB2-F090W-CLEAR: 1.1873
+NRCB2-F115W-CLEAR: 1.1144
+NRCB2-F150W-CLEAR: 1.1165
+NRCB2-F200W-CLEAR: 1.2063
+
+NRCB3-F090W-CLEAR: 1.0946
+NRCB3-F115W-CLEAR: 1.0048
+NRCB3-F150W-CLEAR: 1.0147
+NRCB3-F200W-CLEAR: 1.1098
+
+NRCB4-F090W-CLEAR: 1.2219
+NRCB4-F115W-CLEAR: 1.2036
+NRCB4-F150W-CLEAR: 1.1781
+NRCB4-F200W-CLEAR: 1.2310
+
+# LW *relative* data derived from
+# COM-1063 data in j1235 field
+# Absolute values from the standard observed in the B module for 
+# F277W and F356W look to be ~1.0
+NRCBLONG-F277W-CLEAR: 1.0
+NRCALONG-F277W-CLEAR: 0.903
+NRCBLONG-F356W-CLEAR: 1.0
+NRCALONG-F356W-CLEAR: 0.919
+
+# No absolute value.  Relative value from COM-1063
+NRCBLONG-F300M-CLEAR: 1.0
+NRCALONG-F300M-CLEAR: 0.944
+
+# No absolute value.  A/B roughly interpolated between 356 and 444
+NRCBLONG-F410M-CLEAR: 1.0
+NRCALONG-F410M-CLEAR: 0.95
+
+# F444W BLONG absolute measured from the flux standard
+# B/A relative = 0.965 from the LMC astrometric field
+NRCBLONG-F444W-CLEAR: 0.912
+NRCALONG-F444W-CLEAR: 0.880


### PR DESCRIPTION
As of late August 2022, a number of groups have found that there still seem to be large corrections to the individual NIRCam SCA photometric calibration required, even after the CRDS updates in late July.  There is a series of ongoing calibration programs that will establish the absolute calibration of all of the modes at high precision.  For now, however, those calibration data are incomplete.  

I have derived some corrections to the `jwst_0942.pmap` context using the following:

1) The flux calibration standard `J1743045` suggests that the absolute NIRISS calibration is quite good, with just a correction of 1/1.04 required for F200W
2) The flux standard also suggests that NIRCam LW broadbands are fairly well calibrated, perhaps with the exception of a 1/0.912 correction needed for F444W
3) The flux standard data are currently only available for the B module in some filters.  To calibrate the A module and also the additional broadband SW filters, I derived *relative* corrections using the wealth of data taken of the LMC astrometric calibration field, where certain patches of the field have been observed by more than one NIRCam SCA.  The corrections are derived by measuring photometry in the NIRISS broad bands and then calculating scale factors of all of the NIRCam SW SCAs relative to these.
4) Relative A/B corrections for the NIRCam LW broad-band filters are also derived from the LMC data.

The tabulated values in `grizli/data/photom_correction.yml` are the median ratios of the derived flux densities in the indicated filters to some reference, either relative or absolute.  To apply the corrections relative to exposures calibrated with the current CRDS_CONTEXT, the values should be *divided* from the SCI and ERR arrays, which is now implemented in `utils.drizzle_from_visit`.

The LMC mosaics are available at https://s3.amazonaws.com/grizli-v2/JwstMosaics/lmc-astrometric-field/lmc.html.  The full notebook used to derive the LMC corrections is at https://s3.amazonaws.com/grizli-v2/JwstMosaics/lmc-astrometric-field/astrometric-field-photometry.ipynb.

The figures below show the distribution of flux ratios in the NIRCam LW and SW filters, where the median values are stored in the correction table.

Module ratios for **NIRCam LW**
![nircam_LW_astrometric_field](https://user-images.githubusercontent.com/1577270/186923263-c9785ae7-5ead-4dc1-8516-a0bd72f94973.png)

**NIRCam SW ratios relative to NIRISS**

![nircam_to_niriss-F090W_astrometric_field](https://user-images.githubusercontent.com/1577270/186923268-c256df49-e5be-4224-a090-699cf18f3031.png)
![nircam_to_niriss-F115W_astrometric_field](https://user-images.githubusercontent.com/1577270/186923269-b27394ba-255f-47f5-9f14-d54b0a5fe4e5.png)
![nircam_to_niriss-F150W_astrometric_field](https://user-images.githubusercontent.com/1577270/186923271-961e089a-383b-4dc1-92cb-530e07fc1df3.png)
![nircam_to_niriss-F200W_astrometric_field](https://user-images.githubusercontent.com/1577270/186923273-00aaeb13-137d-4c51-ada2-c03e14023de7.png)

The *multiplicative* corrections are summarized below:
```
# det filt  pupil  mjsr_0942    gbr    ila  mjsr_gbr
# mjsr_0942 : PHOTMJSR from jwst_0942.pmap
# gbr : multiplicative corrections from G. Brammer
# ila : multiplicative corrections from I. Labbe
# mjsr_gbr = gbr * mjsr_0942
NRCA1 F090W CLEAR      3.762  0.826   ---   3.108
NRCA1 F115W CLEAR      3.299  0.914  0.876  3.014
NRCA1 F150W CLEAR      2.460  0.936  0.895  2.303
NRCA1 F200W CLEAR      2.211  0.865  0.846  1.913
NRCA2 F090W CLEAR      3.872  0.833   ---   3.224
NRCA2 F115W CLEAR      3.395  0.908  0.867  3.084
NRCA2 F150W CLEAR      2.531  0.937  0.894  2.371
NRCA2 F200W CLEAR      2.275  0.889  0.857  2.023
NRCA3 F090W CLEAR      4.026  0.762   ---   3.066
NRCA3 F115W CLEAR      3.531  0.862  0.840  3.044
NRCA3 F150W CLEAR      2.632  0.878  0.852  2.310
NRCA3 F200W CLEAR      2.366  0.800  0.794  1.892
NRCA4 F090W CLEAR      3.839  0.753   ---   2.891
NRCA4 F115W CLEAR      3.366  0.813  0.784  2.738
NRCA4 F150W CLEAR      2.509  0.837  0.811  2.100
NRCA4 F200W CLEAR      2.256  0.791  0.778  1.785
NRCB1 F090W CLEAR      3.874  0.894   ---   3.463
NRCB1 F115W CLEAR      3.397  0.959  0.897  3.258
NRCB1 F150W CLEAR      2.532  0.946  0.906  2.394
NRCB1 F200W CLEAR      2.276  0.873  0.866  1.987
NRCB2 F090W CLEAR      4.009  0.842   ---   3.377
NRCB2 F115W CLEAR      3.515  0.897  0.870  3.154
NRCB2 F150W CLEAR      2.621  0.896  0.879  2.348
NRCB2 F200W CLEAR      2.356  0.829  0.847  1.953
NRCB3 F090W CLEAR      3.706  0.914   ---   3.386
NRCB3 F115W CLEAR      3.250  0.995  0.933  3.234
NRCB3 F150W CLEAR      2.423  0.986  0.936  2.388
NRCB3 F200W CLEAR      2.178  0.901  0.888  1.963
NRCB4 F090W CLEAR      3.769  0.818   ---   3.085
NRCB4 F115W CLEAR      3.305  0.831  0.811  2.746
NRCB4 F150W CLEAR      2.464  0.849  0.822  2.092
NRCB4 F200W CLEAR      2.215  0.812  0.795  1.799
NRCBLONG F277W CLEAR   0.422  1.000   ---   0.422
NRCALONG F277W CLEAR   0.433  1.107   ---   0.480
NRCBLONG F356W CLEAR   0.372  1.000   ---   0.372
NRCALONG F356W CLEAR   0.381  1.088   ---   0.415
NRCBLONG F410M CLEAR   0.811  1.000  1.031  0.811
NRCALONG F410M CLEAR   0.832  1.053  1.031  0.876
NRCBLONG F444W CLEAR   0.335  1.096  1.031  0.367
NRCALONG F444W CLEAR   0.343  1.136  1.031  0.390
```
