### PR TITLE
Update F410M correction based on PRIMER overlap

### DIFF
--- a/grizli/data/photom_correction.yml
+++ b/grizli/data/photom_correction.yml
@@ -93,7 +93,9 @@ NRCALONG-F300M-CLEAR: 0.944
 
 # No absolute value.  A/B roughly interpolated between 356 and 444
 NRCBLONG-F410M-CLEAR: 1.0
-NRCALONG-F410M-CLEAR: 0.95
+#NRCALONG-F410M-CLEAR: 0.95
+# From slight overlap in Primer: relative 1.0
+NRCALONG-F410M-CLEAR: 1.01
 
 # F444W BLONG absolute measured from the flux standard
 # B/A relative = 0.965 from the LMC astrometric field

--- a/grizli/data/photom_correction.yml
+++ b/grizli/data/photom_correction.yml
@@ -95,9 +95,9 @@ NRCALONG-F300M-CLEAR: 0.944
 #NRCBLONG-F410M-CLEAR: 1.0
 #NRCALONG-F410M-CLEAR: 0.95
 # From slight overlap in PRIMER: relative A/B 1.01
-# Absolute B=1.02 from PRIMER photoz
-NRCBLONG-F410M-CLEAR: 1.02
-NRCALONG-F410M-CLEAR: 1.03
+# Absolute B=0.96 from PRIMER photoz
+NRCBLONG-F410M-CLEAR: 0.96
+NRCALONG-F410M-CLEAR: 0.97
 
 # F444W BLONG absolute measured from the flux standard
 # B/A relative = 0.965 from the LMC astrometric field

--- a/grizli/data/photom_correction.yml
+++ b/grizli/data/photom_correction.yml
@@ -92,10 +92,12 @@ NRCBLONG-F300M-CLEAR: 1.0
 NRCALONG-F300M-CLEAR: 0.944
 
 # No absolute value.  A/B roughly interpolated between 356 and 444
-NRCBLONG-F410M-CLEAR: 1.0
+#NRCBLONG-F410M-CLEAR: 1.0
 #NRCALONG-F410M-CLEAR: 0.95
-# From slight overlap in Primer: relative 1.0
-NRCALONG-F410M-CLEAR: 1.01
+# From slight overlap in PRIMER: relative A/B 1.01
+# Absolute B=1.02 from PRIMER photoz
+NRCBLONG-F410M-CLEAR: 1.02
+NRCALONG-F410M-CLEAR: 1.03
 
 # F444W BLONG absolute measured from the flux standard
 # B/A relative = 0.965 from the LMC astrometric field


### PR DESCRIPTION
The v4.0 catalogs include the photometry corrections described in https://github.com/gbrammer/grizli/pull/107.  That update included an interpolated value for the F410M filter, which wasn't sampled in the test data.  The eazy zeropoint maps in those catalogs suggest that that interpolated value isn't quite correct, as in the attached figure.

There is a slight overlap between the A/B modules in the F410M PRIMER mosaic that suggests A/B ~ 1.01 rather than the somewhat larger corrections in the wide filters.  Absolute correction remains TBD.

![download-4](https://user-images.githubusercontent.com/1577270/188578019-85b0551f-4d8c-4382-af1e-cfdb1aee1e0b.png)
