### PR TITLE
Implement 1-over-f correction at exposure level

### DIFF
--- a/grizli/jwst_utils.py
+++ b/grizli/jwst_utils.py
@@ -950,6 +950,8 @@ def exposure_oneoverf_correction(file, axis=None, thresholds=[5,4,3], erode_mask
         im[0].header['ONEFEXP'] = True, 'Exposure 1/f correction applied'
         im[0].header['ONEFAXIS'] = axis, 'Axis for 1/f correction'
         
+        model[~np.isfinite(model)] = 0
+        
         im['SCI'].data -= model
         im.flush()
         

--- a/grizli/jwst_utils.py
+++ b/grizli/jwst_utils.py
@@ -211,20 +211,26 @@ def get_jwst_skyflat(header, verbose=True, valid_flat=(0.7, 1.4)):
         return None, None, None
 
     skyflat = pyfits.open(skyfile)[0].data
-
-    oflat = os.path.basename(header['R_FLAT'])
-    crds_path = os.getenv('CRDS_PATH')
-    crds_path = os.path.join(crds_path, 'references/jwst', 
-                             header['instrume'].lower(), oflat)
-
-    oim = pyfits.open(crds_path)
-    try:
-        flat_corr = oim['SCI'].data / skyflat
-    except ValueError:
-        msg = f'jwst_utils.get_jwst_skyflat: flat_corr failed'
-        utils.log_comment(utils.LOGFILE, msg, verbose=True)
-        return None, None, None
-
+        
+    if 'R_FLAT' in header:
+        oflat = os.path.basename(header['R_FLAT'])
+        crds_path = os.getenv('CRDS_PATH')
+        crds_path = os.path.join(crds_path, 'references/jwst', 
+                                 header['instrume'].lower(), oflat)
+        
+        msg = f'jwst_utils.get_jwst_skyflat: pipeline flat = {crds_path}\n'
+        
+        oim = pyfits.open(crds_path)
+        try:
+            flat_corr = oim['SCI'].data / skyflat
+        except ValueError:
+            msg = f'jwst_utils.get_jwst_skyflat: flat_corr failed'
+            utils.log_comment(utils.LOGFILE, msg, verbose=True)
+            return None, None, None
+    else:
+        msg = f'jwst_utils.get_jwst_skyflat: NO pipeline flat\n'
+        flat_corr = 1./skyflat
+        
     bad = skyflat < valid_flat[0]
     bad |= skyflat > valid_flat[1]
     bad |= ~np.isfinite(flat_corr)
@@ -232,10 +238,24 @@ def get_jwst_skyflat(header, verbose=True, valid_flat=(0.7, 1.4)):
     
     dq = bad*1024
 
-    msg = f'jwst_utils.get_jwst_skyflat: pipeline flat = {crds_path}\n'
     msg += f'jwst_utils.get_jwst_skyflat: new sky flat = {skyfile}\n'
     msg += f'jwst_utils.get_jwst_skyflat: valid_flat={valid_flat}'
     msg += f' nmask={bad.sum()}'
+    
+    if 'SUBSTRT1' in header:
+        if header['SUBSIZE1'] != 2048:
+            slx = slice(header['SUBSTRT1']-1,
+                        header['SUBSTRT1']-1 + header['SUBSIZE1'])
+            sly = slice(header['SUBSTRT2']-1,
+                        header['SUBSTRT2']-1 + header['SUBSIZE2'])
+            
+            msg += f"\njwst_utils.get_jwst_skyflat: subarray "
+            msg +=  header['APERNAME']
+            msg += f' [{sly.start}:{sly.stop},{slx.start}:{slx.stop}]'
+            
+            flat_corr = flat_corr[sly, slx]
+            dq = dq[sly, slx]
+            
     utils.log_comment(utils.LOGFILE, msg, verbose=True)
 
     return skyfile, flat_corr, dq
@@ -757,7 +777,190 @@ def copy_jwst_keywords(header, orig_keys=ORIG_KEYS, verbose=True):
                 utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
 
 
-def initialize_jwst_image(filename, verbose=True, max_dq_bit=14, orig_keys=ORIG_KEYS):
+def exposure_oneoverf_correction(file, axis=None, thresholds=[5,4,3], erode_mask=None, dilate_iterations=3, deg_pix=64, make_plot=True, init_model=0, in_place=False, skip_miri=True, verbose=True):
+    """
+    1/f correction for individual exposure
+    
+    1. Create a "background" mask with `sep`
+    2. Identify sources above threshold limit in the background-subtracted
+       image
+    3. Iterate a row/column correction on threshold-masked images.  A 
+       chebyshev polynomial is fit to the correction array to try to isolate
+       just the high-frequency oscillations.
+    
+    Parameters
+    ----------
+    file : str
+        JWST raw image filename
+    
+    axis : int
+        Axis over which to calculated the correction. If `None`, then defaults 
+        to ``axis=1`` (rows) for NIRCam and ``axis=1`` (columns) for NIRISS.
+    
+    thresholds : list
+        List of source identification thresholds
+        
+    erode_mask : bool
+        Erode the source mask to try to remove individual pixels that satisfy
+        the S/N threshold.  If `None`, then set to False if the exposure is a 
+        NIRISS dispersed image to avoid clipping compact high-order spectra
+        from the mask and True otherwise (for NIRISS imaging and NIRCam
+        generally).
+    
+    dilate_iterations : int
+        Number of `binary_dilation` iterations of the source mask
+        
+    deg_pix : int
+        Scale in pixels for each degree of the smooth chebyshev polynomial
+    
+    make_plot : bool
+        Make a diagnostic plot
+    
+    init_model : scalar, array-like
+        Initial correction model, e.g., for doing both axes
+    
+    in_place : bool
+        If True, remove the model from the 'SCI' extension of ``file``
+    
+    skip_miri : bool
+        Don't run on MIRI exposures
+    
+    verbose : bool
+        Print status messages
+        
+    Returns
+    -------
+    fig : `~matplotlib.figure.Figure`, None
+        Diagnostic figure if `make_plot=True`
+    
+    model : array-like
+        The row- or column-average correction array
+    """
+    import numpy as np
+    import scipy.ndimage as nd
+    import matplotlib.pyplot as plt
+    
+    import astropy.io.fits as pyfits
+    import sep
+    
+    im = pyfits.open(file)
+    if (im[0].header['INSTRUME'] in 'MIRI') & (skip_miri):
+        msg = 'exposure_oneoverf_correction: Skip for MIRI'
+        utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
+        
+        return None, 0
+        
+    if axis is None:
+        if im[0].header['INSTRUME'] == 'NIRISS':
+            axis = 0
+        else:
+            axis = 1
+
+    msg = f'exposure_oneoverf_correction: {file} axis={axis}'
+    utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
+    
+    if erode_mask is None:
+        if im[0].header['FILTER'].startswith('GR150'):
+            erode_mask = False
+        else:
+            erode_mask = True
+            
+    dq = utils.unset_dq_bits(im['DQ'].data, 4)
+    dqmask = dq == 0
+    mask = dqmask
+
+    err = im['ERR'].data
+    dqmask &= (err > 0) & np.isfinite(err)
+
+    sci = im['SCI'].data.astype(np.float32) - init_model
+    bkg = sep.Background(sci, mask=~dqmask, bw=deg_pix, bh=deg_pix)
+    back = bkg.back()
+
+    sn_mask = (sci - back)/err > thresholds[0]
+    if erode_mask:
+        sn_mask = nd.binary_erosion(sn_mask)
+        
+    sn_mask = nd.binary_dilation(sn_mask, iterations=dilate_iterations)
+
+    mask = dqmask & ~sn_mask
+
+    cheb = 0
+    
+    if make_plot:
+        fig, ax = plt.subplots(1,1,figsize=(6,3))
+    else:
+        fig = None
+        
+    for _iter, thresh in enumerate(thresholds):
+        sci = im['SCI'].data*1. - back - init_model
+        sci[~mask] = np.nan
+        med = np.nanmedian(sci, axis=axis)
+
+        if axis == 0:
+            model = np.zeros_like(sci) + (med - cheb)
+        else:
+            model = (np.zeros_like(sci) + (med - cheb)).T
+
+        sn_mask = ((sci-model)/err > thresh) & dqmask
+        if erode_mask:
+            sn_mask = nd.binary_erosion(sn_mask)
+        
+        sn_mask = nd.binary_dilation(sn_mask, iterations=dilate_iterations)
+        mask = dqmask & ~sn_mask
+        mask &= (sci-model)/err > -thresh
+
+        if make_plot:
+            ax.plot(med, alpha=0.5)
+
+    nx = med.size
+    xarr = np.linspace(-1,1,nx)
+    deg = nx//deg_pix
+
+    ok = np.isfinite(med)
+
+    if deg <= 1:
+        cheb = np.nanmedian(med)
+    else:
+        for _iter in range(3):
+            coeffs = np.polynomial.chebyshev.chebfit(xarr[ok], med[ok], deg)
+            cheb = np.polynomial.chebyshev.chebval(xarr, coeffs)
+            ok = np.isfinite(med) & (np.abs(med-cheb) < 0.05)
+
+        if make_plot:
+            ax.plot(np.arange(nx)[ok], cheb[ok], color='r')
+
+    if axis == 0:
+        model = np.zeros_like(sci) + (med - cheb)
+    else:
+        model = (np.zeros_like(sci) + (med - cheb)).T
+    
+    if make_plot:
+        ax.set_title(f'{file} axis={axis}')
+        ax.grid()
+        
+        fig.tight_layout(pad=0)
+    
+    im.close()
+    
+    if in_place: 
+        msg = f'exposure_oneoverf_correction: {file} apply to file'
+        utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
+        
+        im = pyfits.open(file, mode='update')
+        im[0].header['ONEFEXP'] = True, 'Exposure 1/f correction applied'
+        im[0].header['ONEFAXIS'] = axis, 'Axis for 1/f correction'
+        
+        im['SCI'].data -= model
+        im.flush()
+        
+        if make_plot:
+            fig.savefig(file.split('.fits')[0] + f'_onef_axis{axis}.png')
+            plt.close('all')
+            
+    return fig, model
+
+
+def initialize_jwst_image(filename, verbose=True, max_dq_bit=14, orig_keys=ORIG_KEYS, oneoverf_correction=True, oneoverf_kwargs={'make_plot':False}):
     """
     Make copies of some header keywords to make the headers look like 
     and HST instrument
@@ -765,8 +968,9 @@ def initialize_jwst_image(filename, verbose=True, max_dq_bit=14, orig_keys=ORIG_
     1) Apply gain correction [x remove]
     2) Clip DQ bits
     3) Copy header keywords
-    4) Apply flat field if necessary
-    5) Initalize WCS
+    4) Apply exposure-level 1/f correction
+    5) Apply flat field if necessary
+    6) Initalize WCS
     
     Returns
     -------
@@ -925,6 +1129,16 @@ def initialize_jwst_image(filename, verbose=True, max_dq_bit=14, orig_keys=ORIG_
     img.writeto(filename, overwrite=True)
     img.close()
     
+    if oneoverf_correction:
+        try:
+            _ = exposure_oneoverf_correction(filename, in_place=True, 
+                                         **oneoverf_kwargs)
+        except TypeError:
+            # Should only fail for test data
+            pass
+                                         
+        # axis=None, thresholds=[5,4,3], erode_mask=None, dilate_iterations=3, deg_pix=64, make_plot=True, init_model=0, in_place=False, skip_miri=True, verbose=True
+        
     _ = img_with_flat(filename, overwrite=True)
 
     _ = img_with_wcs(filename, overwrite=True)

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -2666,10 +2666,39 @@ def make_drz_catalog(root='', sexpath='sex', threshold=2., get_background=True,
     return cat
 
 
-def make_miri_average_flat(visit, clip_max=1, apply=True, verbose=True):
+def make_visit_average_flat(visit, clip_max=0, threshold=5, dilate=3, apply=True, instruments=['MIRI'], verbose=True):
     """
-    Make an average MIRI "skyflat" for exposures in a visit
+    Make an average "skyflat" for exposures in a visit, e.g., for MIRI
+    
+    Parameters
+    ----------
+    visit : dict
+        Visit dictionary with, at a minimum, keys of ``product`` and ``files``
+    
+    clip_max : int
+        Number of max clipping iterations
+    
+    threshold : float
+        If specified, run `sep` source detection on each exposure
+    
+    dilate : int
+        Number of `scipy.ndimage.binary_dilation` iterations to run on the 
+        segmentation mask
+    
+    apply : bool
+        Apply the flat to the exposures 
+    
+    instruments : list
+        Only run for these instruments (from INSTRUME header keyword)
+        
+    verbose : bool
+        Print status messages
+        
     """
+    from tqdm import tqdm
+    import scipy.ndimage as nd
+    import sep
+    
     _im = pyfits.open(visit['files'][0])
     
     if 'OINSTRUM' in _im[0].header:
@@ -2677,17 +2706,40 @@ def make_miri_average_flat(visit, clip_max=1, apply=True, verbose=True):
     else:
         instrument = _im[0].header['INSTRUME']
         
-    if instrument not in ['MIRI']:
-        msg = f"make_miri_average_flat: Instrument for {visit['product']} "
+    if instrument not in instruments:
+        msg = f"make_visit_average_flat: Instrument for {visit['product']} "
         msg += f"is {instrument}, skip flat"
         utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
         
         return None
         
-    sci = np.array([pyfits.open(file)['SCI'].data
+    sci = np.array([pyfits.open(file)['SCI'].data.astype(np.float32)
                     for file in visit['files']])
     dq = np.array([pyfits.open(file)['DQ'].data
                     for file in visit['files']])
+
+    if threshold is not None:
+        
+        msg = f"make_visit_average_flat: Source detection on individual"
+        msg += f" exposures with threshold={threshold} dilate={dilate}"
+        utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
+        
+        err = np.array([pyfits.open(file)['ERR'].data.astype(np.float32)
+                        for file in visit['files']])
+        
+        #mask = im['DQ'].data > 0
+        for i in tqdm(range(len(visit['files']))):
+            _sci = sci[i,:,:]
+            _err = err[i,:,:]
+            _mask = dq[i,:,:] > 0
+            _bkg = sep.Background(_sci, mask=_mask)
+            _cat, _seg = sep.extract(_sci - _bkg.back(), threshold,
+                                    err=_err, 
+                                    mask=_mask,
+                                    segmentation_map=True)
+
+            _segm = nd.binary_dilation(_seg > 0, iterations=dilate)
+            _sci[_segm > 0] = np.nan
     
     scim = sci*1.
     for _iter in range(clip_max):
@@ -2721,21 +2773,21 @@ def make_miri_average_flat(visit, clip_max=1, apply=True, verbose=True):
     skyfile = f"{visit['product']}_skyflat.fits"
     _hdu.writeto(skyfile, overwrite=True)
     
-    msg = f"make_miri_average_flat: {skyfile} N={len(visit['files'])}"
+    msg = f"make_visit_average_flat: {skyfile} N={len(visit['files'])}"
     msg += f" clip_max={clip_max}"
     utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
     
     if apply:
-        apply_miri_skyflat(visit, skyfile=skyfile)
+        apply_visit_skyflat(visit, skyfile=skyfile)
 
 
-def apply_miri_skyflat(visit, skyfile=None, verbose=True):
+def apply_visit_skyflat(visit, skyfile=None, verbose=True):
     """
-    Apply the MIRI skyflat
+    Apply the skyflat
     """
     
     if not os.path.exists(skyfile):
-        msg = f"apply_miri_skyflat: MIRI skyflat {skyfile} not found"
+        msg = f"apply_visit_skyflat: MIRI skyflat {skyfile} not found"
         utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
         return None
     
@@ -2744,7 +2796,7 @@ def apply_miri_skyflat(visit, skyfile=None, verbose=True):
     flat[flat_mask] = 1
     
     for file in visit['files']:
-        msg = f"make_miri_average_flat: apply {skyfile} to {file}"
+        msg = f"apply_visit_skyflat: apply {skyfile} to {file}"
         utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
         
         with pyfits.open(file, mode='update') as _imi:
@@ -3688,9 +3740,9 @@ def process_direct_grism_visit(direct={},
         
         if isJWST:
             if miri_skyflat:
-                make_miri_average_flat(direct)
+                make_visit_average_flat(direct)
             elif miri_skyfile is not None:
-                apply_miri_skyflat(direct, skyfile=miri_skyfile)
+                apply_visit_skyflat(direct, skyfile=miri_skyfile)
     
     # Initial grism processing
     skip_grism = (grism == {}) | (grism is None) | (len(grism) == 0)

--- a/grizli/tests/test_jwst.py
+++ b/grizli/tests/test_jwst.py
@@ -40,6 +40,12 @@ class JWSTHeaders(unittest.TestCase):
         path_to_files = os.path.join(path, 'tests/data/jwst-headers/')
         return path_to_files
         
+    def fetch_test_data(self):
+        """
+        Fetch test data from MAST
+        """
+        pass
+        
     def test_process_headers(self, clean=True):
         """
         """


### PR DESCRIPTION
Source-masked 1/f correction implemented in `jwst_utils.exposure_oneoverf_correction`

This PR also implements source-masking in the sky flat routine, e.g., for MIRI.  Before the masking was a simple maximum clipping filter.