### PR TITLE
Updates for NIRCam WFSS based on the first FRESCO visits

### DIFF
--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -1142,7 +1142,11 @@ def check_jwst_assoc_guiding(assoc):
     
     for i, row in enumerate(atab):
         gsx = (tab['time'] > row['t_min']) & (tab['time'] < row['t_max'])
-        gs_stats = np.percentile(tab['jitter'][gsx], [16, 50, 84])
+        
+        if gsx.sum() == 0:
+            gs_stats = [-1,-1,-1]
+        else:
+            gs_stats = np.percentile(tab['jitter'][gsx], [16, 50, 84])
 
         atab['jitter16'][i] = gs_stats[0]
         atab['jitter50'][i] = gs_stats[1]

--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -903,6 +903,8 @@ class TransformGrismconf(object):
             trace_dy += -2.5
         elif os.path.basename(self.conf_file) == 'NIRCAM_F444W_modA_C.conf':
             trace_dy += -0.1
+        elif 'V4/NIRCAM_F444W_modB_R.conf' in self.conf_file:
+            trace_dy -= 0.5
             
         wave = self.conf.DISPL(self.order_names[beam], *x0, t)
         if self.transform.instrument != 'HST':
@@ -952,7 +954,7 @@ class TransformGrismconf(object):
             #self.beams.append(beam)
             self.dxlam[beam] = np.arange(xarr[0], xarr[-1], dtype=int)
             self.nx[beam] = xarr[-1] - xarr[0]+1
-
+                        
             sens = Table()
             sens['WAVELENGTH'] = lam.astype(np.double)
             sens['SENSITIVITY'] = self.conf.SENS[order](lam).astype(np.double)

--- a/grizli/jwst_utils.py
+++ b/grizli/jwst_utils.py
@@ -862,7 +862,7 @@ def exposure_oneoverf_correction(file, axis=None, thresholds=[5,4,3], erode_mask
         else:
             axis = 1
 
-    msg = f'exposure_oneoverf_correction: {file} axis={axis}'
+    msg = f'exposure_oneoverf_correction: {file} axis={axis} deg_pix={deg_pix}'
     utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
     
     if im[0].header['INSTRUME'] in ('NIRSPEC'):
@@ -884,7 +884,12 @@ def exposure_oneoverf_correction(file, axis=None, thresholds=[5,4,3], erode_mask
     dqmask &= (err > 0) & np.isfinite(err)
 
     sci = im['SCI'].data.astype(np.float32) - init_model
-    bkg = sep.Background(sci, mask=~dqmask, bw=deg_pix, bh=deg_pix)
+    if deg_pix == 0:
+        bw = sci.shape[0] // 64
+    else:
+        bw = deg_pix
+        
+    bkg = sep.Background(sci, mask=~dqmask, bw=bw, bh=bw)
     back = bkg.back()
 
     sn_mask = (sci - back)/err > thresholds[0]
@@ -903,7 +908,12 @@ def exposure_oneoverf_correction(file, axis=None, thresholds=[5,4,3], erode_mask
         fig = None
         
     for _iter, thresh in enumerate(thresholds):
-        sci = im['SCI'].data*1. - back - init_model
+        
+        if deg_pix == 0:
+            sci = im['SCI'].data*1. - init_model
+        else:
+            sci = im['SCI'].data*1. - back - init_model
+            
         sci[~mask] = np.nan
         med = np.nanmedian(sci, axis=axis)
 
@@ -925,13 +935,22 @@ def exposure_oneoverf_correction(file, axis=None, thresholds=[5,4,3], erode_mask
 
     nx = med.size
     xarr = np.linspace(-1,1,nx)
-    deg = nx//deg_pix
-
     ok = np.isfinite(med)
-
-    if deg <= 1:
+    
+    if deg_pix == 0:
+        # Don't remove anything from the median profile
+        cheb = 0.
+        deg = -1
+        
+    elif deg_pix >= nx:
+        # Remove constant component
         cheb = np.nanmedian(med)
+        deg = 0
+        
     else:
+        # Remove smooth component
+        deg = nx//deg_pix
+        
         for _iter in range(3):
             coeffs = np.polynomial.chebyshev.chebfit(xarr[ok], med[ok], deg)
             cheb = np.polynomial.chebyshev.chebval(xarr, coeffs)
@@ -960,6 +979,8 @@ def exposure_oneoverf_correction(file, axis=None, thresholds=[5,4,3], erode_mask
         with pyfits.open(file, mode='update') as im:
             im[0].header['ONEFEXP'] = True, 'Exposure 1/f correction applied'
             im[0].header['ONEFAXIS'] = axis, 'Axis for 1/f correction'
+            im[0].header['ONEFDEG'] = deg, 'Degree of smooth component'
+            im[0].header['ONEFNPIX'] = deg_pix, 'Pixels per smooth degree'
         
             model[~np.isfinite(model)] = 0
         
@@ -1152,21 +1173,60 @@ def initialize_jwst_image(filename, verbose=True, max_dq_bit=14, orig_keys=ORIG_
     img.writeto(filename, overwrite=True)
     img.close()
     
+    _nircam_grism = False
+    
     if oneoverf_correction:
-        try:
-            _ = exposure_oneoverf_correction(filename, in_place=True, 
-                                         **oneoverf_kwargs)
-        except TypeError:
-            # Should only fail for test data
-            utils.log_exception(utils.LOGFILE, traceback)
-            msg = f'exposure_oneoverf_correction: failed for {filename}'
-            utils.log_comment(utils.LOGFILE, msg)
+        
+        # NIRCam grism
+        if ((img[0].header['OINSTRUM'] == 'NIRCAM') & 
+            ('GRISM' in img[0].header['OPUPIL'])):
+
+            _nircam_grism = True
+
+        else:
             
-            pass
+            try:
+                _ = exposure_oneoverf_correction(filename, in_place=True, 
+                                             **oneoverf_kwargs)
+            except TypeError:
+                # Should only fail for test data
+                utils.log_exception(utils.LOGFILE, traceback)
+                msg = f'exposure_oneoverf_correction: failed for {filename}'
+                utils.log_comment(utils.LOGFILE, msg)
+            
+                pass
                                          
         # axis=None, thresholds=[5,4,3], erode_mask=None, dilate_iterations=3, deg_pix=64, make_plot=True, init_model=0, in_place=False, skip_miri=True, verbose=True
         
     _ = img_with_flat(filename, overwrite=True, use_skyflats=use_skyflats)
+    
+    # Now do "1/f" correction to subtract NIRCam grism sky
+    if _nircam_grism:
+        if img[0].header['OPUPIL'] == 'GRISMR':
+            _disp_axis = 0
+        else:
+            _disp_axis = 1
+        
+        msg = f'exposure_oneoverf_correction: NIRCam grism sky {filename}'
+        utils.log_comment(utils.LOGFILE, msg)
+
+        # # Subtract simple median
+        # exposure_oneoverf_correction(filename,
+        #                              in_place=True,
+        #                              erode_mask=False,
+        #                              thresholds=[4,3],
+        #                              axis=_disp_axis,
+        #                              dilate_iterations=5,
+        #                              deg_pix=0)
+
+        # Subtract average along dispersion axis    
+        exposure_oneoverf_correction(filename,
+                                     in_place=True, 
+                                     erode_mask=False,
+                                     thresholds=[4,3],
+                                     axis=_disp_axis,
+                                     dilate_iterations=5,
+                                     deg_pix=0)
 
     _ = img_with_wcs(filename, overwrite=True)
     

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -5320,6 +5320,12 @@ def visit_grism_sky(grism={}, apply=True, column_average=True, verbose=True, ext
     isJWST = False
     isACS = False
     
+    # Skip NIRCam grism
+    if 'GRISM' in grism_element:
+        logstr = f'# visit_grism_sky: skip for {grism_element}'
+        utils.log_comment(utils.LOGFILE, logstr, verbose=verbose)
+        return False
+        
     flat = 1.
     if grism_element == 'G141':
         bg_fixed = ['zodi_G141_clean.fits']

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -98,7 +98,8 @@ GRISM_LIMITS = {'G800L': [0.545, 1.02, 40.],  # ACS/WFC
 #DEFAULT_LINE_LIST = ['PaB', 'HeI-1083', 'SIII', 'OII-7325', 'ArIII-7138', 'SII', 'Ha+NII', 'OI-6302', 'HeI-5877', 'OIII', 'Hb', 'OIII-4363', 'Hg', 'Hd', 'H8','H9','NeIII-3867', 'OII', 'NeVI-3426', 'NeV-3346', 'MgII','CIV-1549', 'CIII-1908', 'OIII-1663', 'HeII-1640', 'NIII-1750', 'NIV-1487', 'NV-1240', 'Lya']
 
 # Line species for determining individual line fluxes.  See `load_templates`.
-DEFAULT_LINE_LIST = ['PaB', 'HeI-1083', 'SIII', 'OII-7325', 'ArIII-7138',
+DEFAULT_LINE_LIST = ['BrA','BrB','PfG','PfD',
+                     'PaA','PaB', 'HeI-1083', 'SIII', 'OII-7325', 'ArIII-7138',
                      'SII', 'Ha', 'OI-6302', 'HeI-5877', 'OIII', 'Hb', 
                      'OIII-4363', 'Hg', 'Hd', 'H7', 'H8', 'H9', 'H10', 
                      'NeIII-3867', 'OII', 'NeVI-3426', 'NeV-3346', 'MgII', 
@@ -1871,6 +1872,14 @@ def get_line_wavelengths():
     line_ratios = OrderedDict()
 
     # Paschen: https://www.gemini.edu/sciops/instruments/nearir-resources/astronomical-lines/h-lines
+    line_wavelengths['BrA'] = [40522.8]
+    line_ratios['BrA'] = [1.]
+    line_wavelengths['BrB'] = [26258.7]
+    line_ratios['BrB'] = [1.]
+    line_wavelengths['PfG'] = [37405.76]
+    line_ratios['PfG'] = [1.]
+    line_wavelengths['PfD'] = [32969.8]
+    line_ratios['PfD'] = [1.]
     line_wavelengths['PaA'] = [18751.0]
     line_ratios['PaA'] = [1.]
     line_wavelengths['PaB'] = [12821.6]


### PR DESCRIPTION
- Turn off background subtraction with master sky
- Rather, do background subtraction using row/column averages in the oneoverf script
- Add small shift to V4/F444W_modB traces.  The traces still don't line up fully across the detector but this helps
- Fix bugs passing the NIRCam module in the `model.ImageData` class
- Add option to set a reference wavelength for the polynomial contam models
- Add mid-IR recombination lines to the line lists
