### PR TITLE
Add functions for faster nan filtering

### DIFF
--- a/grizli/model.py
+++ b/grizli/model.py
@@ -2293,7 +2293,10 @@ class ImageData(object):
         hdu.append(pyfits.ImageHDU(data=err_data, header=h,
                                    name='ERR'))
         hdu.append(pyfits.ImageHDU(data=self.data['DQ'], header=h, name='DQ'))
-
+        
+        if 'MED' in self.data:
+            hdu.append(pyfits.ImageHDU(data=self.data['MED'], header=h, name='MED'))
+            
         if self.data['REF'] is not None:
             h['PHOTFLAM'] = self.ref_photflam
             h['PHOTPLAM'] = self.ref_photplam
@@ -2307,6 +2310,7 @@ class ImageData(object):
 
         return hdul
 
+
     def __getitem__(self, ext):
         if self.data[ext] is None:
             return None
@@ -2317,6 +2321,7 @@ class ImageData(object):
             return self.data['DQ']
         else:
             return self.data[ext]/self.photflam
+
 
     def get_common_slices(self, other, verify_parent=True):
         """
@@ -2570,7 +2575,8 @@ class GrismFLT(object):
         
         if _DIRECT_OPEN:
             direct_im.close()
-            
+
+
     def process_ref_file(self, ref_file, ref_ext=0, shrink_segimage=True,
                          verbose=True):
         """Read and blot a reference image

--- a/grizli/nbutils.py
+++ b/grizli/nbutils.py
@@ -1,0 +1,102 @@
+"""
+Numba-accelerated functions for filtering with `scipy.LowLevelallable`
+
+Inspired by the beautifully simply example from Juan Nunez-Iglesias
+https://ilovesymposia.com/2017/03/12/scipys-new-lowlevelcallable-is-a-game-changer/
+
+>>> import numpy as np
+>>> import scipy.ndimage as nd
+>>> import grizli.nbutils
+>>> arr = np.random.normal(size=1024)
+>>> footprint = np.ones(51, dtype=int)
+>>> # Slow with numpy overheads
+>>> np_filtered = nd.generic_filter(arr, np.nanmedian, footprint=footprint))
+>>> # Much faster!
+>>> filtered = nd.generic_filter(arr, grizli.nbutils.nanmedian, footprint=footprint))
+
+"""
+
+import numpy as np
+
+from numba import cfunc, carray
+from numba.types import intc, intp, float64, voidptr
+from numba.types import CPointer
+
+from scipy import LowLevelCallable
+
+
+@cfunc(intc(CPointer(float64), intp, CPointer(float64), voidptr))
+def nb_nanmin(values_ptr, len_values, result, data):
+    """
+    Manual minimum
+    """
+    values = carray(values_ptr, (len_values,), dtype=float64)
+    result[0] = np.inf
+    for v in values:
+        if (v < result[0]) & ~np.isnan(v):
+            result[0] = v
+    return 1
+
+
+@cfunc(intc(CPointer(float64), intp, CPointer(float64), voidptr))
+def nb_nanmax(values_ptr, len_values, result, data):
+    """
+    Manual minimum
+    """
+    values = carray(values_ptr, (len_values,), dtype=float64)
+    result[0] = -np.inf
+    for v in values:
+        if (v > result[0]) & ~np.isnan(v):
+            result[0] = v
+    return 1
+
+
+@cfunc(intc(CPointer(float64), intp, CPointer(float64), voidptr))
+def nb_npnanmin(values_ptr, len_values, result, data):
+    """
+    numpy.nanmin
+    """
+    values = carray(values_ptr, (len_values,), dtype=float64)
+    result[0] = np.nanmin(values)
+    return 1
+
+
+@cfunc(intc(CPointer(float64), intp, CPointer(float64), voidptr))
+def nb_npnanmedian(values_ptr, len_values, result, data):
+    """
+    numpy.nanmedian
+    """
+    values = carray(values_ptr, (len_values,), dtype=float64)
+    result[0] = np.nanmedian(values)
+    return 1
+
+
+@cfunc(intc(CPointer(float64), intp, CPointer(float64), voidptr))
+def nb_npnanmean(values_ptr, len_values, result, data):
+    """
+    numpy.nanmean
+    """
+    values = carray(values_ptr, (len_values,), dtype=float64)
+    result[0] = np.nanmean(values)
+
+    return 1
+
+
+@cfunc(intc(CPointer(float64), intp, CPointer(float64), voidptr))
+def nb_npnansum(values_ptr, len_values, result, data):
+    """
+    numpy.nansum
+    """
+    values = carray(values_ptr, (len_values,), dtype=float64)
+    result[0] = np.nansum(values)
+
+    return 1
+
+
+# Callables for scipy.ndimage.generic_filter
+nanmin = LowLevelCallable(nb_nanmin.ctypes)
+nanmax = LowLevelCallable(nb_nanmax.ctypes)
+nbnanmin = LowLevelCallable(nb_npnanmin.ctypes)
+nanmedian = LowLevelCallable(nb_npnanmedian.ctypes)
+nanmean = LowLevelCallable(nb_npnanmean.ctypes)
+nansum = LowLevelCallable(nb_npnansum.ctypes)


### PR DESCRIPTION
Add functions in `nbutils.py` to greatly speed up nanmedian image filtering.  Requires `numba`, but falls back to normal median filtering if `import grizli.nbutils` fails.

Also, add the `MED` extension, if it exists, to the beam cutouts.