### PR TITLE
Add grismconf and numba to jwst requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,8 @@ docs =
 jwst =
     jwst
     pysiaf
+    grismconf
+    numba
 aws =
     awscli
     boto3


### PR DESCRIPTION
Add a few requirements to the `jwst` installation, i.e., `pip install .[jwst]`.

- [grismconf](https://github.com/npirzkal/GRISMCONF) is used for NIRCam WFSS 
- `numba` is used for the accelerated masked filtering functions in [grizli/nbutils.py](https://github.com/gbrammer/grizli/blob/master/grizli/nbutils.py)