### PR TITLE
Simplify requirements for base installation

### DIFF
--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -111,7 +111,11 @@ def fresh_flt_file(file, preserve_dq=False, path='../RAW/', verbose=True, extra_
 
     """
     import shutil
-    from astroscrappy import detect_cosmics
+    try:
+        from astroscrappy import detect_cosmics
+        has_scrappy = True
+    except ImportError:
+        has_scrappy = False
 
     local_file = os.path.basename(file)
     if preserve_dq:
@@ -275,13 +279,13 @@ def fresh_flt_file(file, preserve_dq=False, path='../RAW/', verbose=True, extra_
     #     extra_msg = ' / flat: {0}'.format(flat_file)
     # 
     #     flat_im = pyfits.open(os.path.join(os.getenv('jref'), flat_file))
-    #     flat = flat_im['SCI'].data #[5:-5, 5:-5]
+    #     flat = flat_im['SCI'].data #[5:-5, 5:-5]:
     #     flat_dq = (flat < 0.2)
     # 
     #     #orig_file['DQ'].data |= 4*flat_dq
     #     orig_file['SCI'].data = np.divide(orig_file['SCI'].data,flat,orig_file['SCI'].data,where=(flat!=0))
     
-    if crclean:
+    if crclean and has_scrappy:
         for ext in [1, 2]:
             print('Clean CRs with LACosmic, extension {0:d}'.format(ext))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,16 +23,13 @@ install_requires =
     astro-prospector
     astropy
     astroquery
-    astroscrappy
     descartes
-    drizzlepac
     eazy
     extinction
     mastquery
     matplotlib
     numpy
     peakutils
-    photutils
     # pyia
     # pyregion  # install fails for ubuntu in GitHub CI
     scikit-image
@@ -40,9 +37,7 @@ install_requires =
     scipy
     sep
     shapely
-    specutils
     sregion
-    stsci.tools
     stwcs
     tqdm
     tristars
@@ -53,6 +48,7 @@ include_package_data = True
 test =
     pytest>=5.1
     flake8
+    drizzlepac
 docs =
     sphinx
     sphinx-astropy
@@ -61,6 +57,7 @@ jwst =
     pysiaf
     grismconf
     numba
+    drizzlepac
 aws =
     awscli
     boto3
@@ -68,7 +65,10 @@ aws =
     sqlalchemy
 hst = 
     reprocess-wfc3
-
+    astroscrappy
+    drizzlepac
+    stsci.tools
+    
 [options.package_data]
 grizli.data =
     *.yml


### PR DESCRIPTION
- Put `drizzlepac` in HST and JWST requirements
- Remove `specutils`
- Put `astroscrappy` in HST requirements