### PR TITLE
Add pyregion dependency to install_requires

### DIFF
--- a/.github/workflows/python-package-with-jwst.yml
+++ b/.github/workflows/python-package-with-jwst.yml
@@ -23,14 +23,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package
       run: |
         pip install --upgrade pip
-        pip install astropy-helpers
-        pip install git+https://github.com/astropy/pyregion
         pip install .[jwst,test]
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build check
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package
@@ -55,8 +55,10 @@ jobs:
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package

--- a/docs/grizli/install.rst
+++ b/docs/grizli/install.rst
@@ -6,7 +6,6 @@ The easiest way to install the latest ``grizli`` release into a :ref:`fresh virt
 .. code-block:: bash
 
    pip install grizli
-   pip install pyregion
 
 If you are installing ``grizli`` for the first time, make sure to also set up :ref:`directories and download 
 reference files <directories>`. If you will be working with HST data, the following will install all 
@@ -15,7 +14,6 @@ necessary libraries:
 .. code-block:: bash
 
    pip install "grizli[hst]"
-   pip install pyregion
    conda install hstcal
 
 If you will be working with JWST data, the following is the recommended installation process:
@@ -23,7 +21,6 @@ If you will be working with JWST data, the following is the recommended installa
 .. code-block:: bash
 
    pip install "grizli[jwst]"
-   pip install pyregion
 
 
 More detailed instructions are available :ref:`below <installation>`.
@@ -106,15 +103,9 @@ To minimize conflict of dependencies, install only the ones that you need.
 Additional dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-``pip`` will install all needed dependencies with the exception of the following which 
-need to be installed separately:
-
-.. code-block:: bash
-  
-  pip install pyregion
-  
-If you will be working with HST data, you will also need the ``hstcal`` library 
-which is only available via ``conda``:
+``pip`` will install all needed dependencies.  If you will be working with
+HST data, you will also need the ``hstcal`` library which is only available 
+via ``conda``:
 
 .. code-block:: bash
 

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ channels:
 - http://ssb.stsci.edu/astroconda
 - defaults
 dependencies:
-- pyregion
 - hstcal
 - pip:
   - git+https://github.com/gbrammer/reprocess_wfc3.git

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     numpy
     peakutils
     # pyia
-    # pyregion  # install fails for ubuntu in GitHub CI
+    pyregion
     scikit-image
     scikit-learn
     scipy


### PR DESCRIPTION
The `pyregion` package was released recently with fixes so it will install under modern python build systems.  (Thanks @larrybradley).  It now installs under Linux and can be added as a normal dependency to `grizli`.

Installation docs are updated appropriately.

@gbrammer if you decide to eventually take the time to switch over to [astropy/regions](https://github.com/astropy/regions), ping me in the PR, as your changes in `grizli` might be a nice starting point for docs changes in `pyregion` to show people how to do the switch over.  I'd be happy to do the docs changes over there.