### PR TITLE
Use updated NIRISS conf files

### DIFF
--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -680,14 +680,14 @@ def show_recent_assoc(limit=50):
     return last
 
 
-def launch_ec2_instances(nmax=50, count=None, templ='lt-0e8c2b8611c9029eb,Version=19'):
+def launch_ec2_instances(nmax=50, count=None, templ='lt-0e8c2b8611c9029eb,Version=24'):
     """
     Launch EC2 instances from a launch template that run through all 
     status=0 associations/tiles and then terminate
     
     Version 19 is the latest run_all_visits.sh
     Version 20 is the latest run_all_tiles.sh
-    
+    Version 24 is run_all_visits with a new python39 environment
     """
 
     if count is None:


### PR DESCRIPTION
@jkmatharu has derived updates to the spatial dependence of the NIRISS traces using a large suite of spectra extracted from a commissioning program in the LMC.  Most importantly, these include the spatial dependence of the wavelength zeropoint (`DLDP_{beam}_0`), which was assumed to be constant in earlier versions of the files used by `grizli`.

Cross-dispersion zeropoint (`DYDX_0`)
----------------------------------------

![f150w_gr150c_dydx_a_0](https://user-images.githubusercontent.com/1577270/208110585-87728571-304c-4e03-8698-ee9a34233a76.png)

Wavelength zeropoint (`DLDP_0`)
----------------------------------

![f150w_gr150r_dldp_a_0](https://user-images.githubusercontent.com/1577270/208110857-5e67ca85-7d92-46c4-b634-d16078c2cc03.png)

The updated conf files are made available at https://zenodo.org/record/7443302 with additional information on how they were derived.  Please cite Matharu (2022) `doi:10.5281/zenodo.7443302` if you use them.   Here is a quick script for installing the config files in your `grizli` path:

```python
import os
import grizli
os.chdir(os.path.join(grizli.GRIZLI_PATH, 'CONF'))
if not os.path.exists('GR150C.F115W.221215.conf'):
    os.system('wget "https://zenodo.org/record/7443303/files/niriss_config_221215.tar.gz?download=1" -O niriss_config_221215.tar.gz')
    os.system('tar xzvf niriss_config_221215.tar.gz')
```