### PR TITLE
Convert code to use regions instead of pyregion

### DIFF
--- a/grizli/model.py
+++ b/grizli/model.py
@@ -3918,7 +3918,7 @@ class GrismFLT(object):
 
         xy_image[:, 0] += xedge
 
-        xy_str = 'image;polygon('+','.join(['{0:.1f}'.format(p) for p in xy_image.flatten()])+')'
+        xy_str = 'image;polygon('+','.join(['{0:.1f}'.format(p + 1) for p in xy_image.flatten()])+')'
         reg = pyregion.parse(xy_str)
         mask = reg.get_mask(shape=tuple(self.grism.sh))*1 == 0
 

--- a/grizli/model.py
+++ b/grizli/model.py
@@ -3893,7 +3893,7 @@ class GrismFLT(object):
         """
         Mask edges of exposures that might not have modeled spectra
         """
-        import pyregion
+        from regions import Regions
         import scipy.ndimage as nd
 
         if (self.has_edge_mask) & (force is False):
@@ -3919,8 +3919,8 @@ class GrismFLT(object):
         xy_image[:, 0] += xedge
 
         xy_str = 'image;polygon('+','.join(['{0:.1f}'.format(p + 1) for p in xy_image.flatten()])+')'
-        reg = pyregion.parse(xy_str)
-        mask = reg.get_mask(shape=tuple(self.grism.sh))*1 == 0
+        reg = Regions.parse(xy_str, format='ds9')[0]
+        mask = reg.to_mask().to_image(shape=self.grism.sh).astype(bool)
 
         # Only mask large residuals
         if resid_sn > 0:

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -322,7 +322,7 @@ def blot_nearest_exact(in_data, in_wcs, out_wcs, verbose=True, stepsize=-1,
         scales (out**2/in**2), i.e., the pixel areas.
 
     wcs_mask : bool
-        Use fast WCS masking.  If False, use `pyregion`.
+        Use fast WCS masking.  If False, use ``regions``.
 
     fill_value : int/float
         Value in `out_data` not covered by `in_data`.
@@ -333,8 +333,8 @@ def blot_nearest_exact(in_data, in_wcs, out_wcs, verbose=True, stepsize=-1,
         Blotted data.
 
     """
+    from regions import Regions
     from shapely.geometry import Polygon
-    import pyregion
     import scipy.ndimage as nd
     from drizzlepac import cdriz
 
@@ -384,8 +384,8 @@ def blot_nearest_exact(in_data, in_wcs, out_wcs, verbose=True, stepsize=-1,
     else:
         olap_poly = np.array(olap.exterior.xy)
         poly_reg = "fk5\npolygon("+','.join(['{0}'.format(p + 1) for p in olap_poly.T.flatten()])+')\n'
-        reg = pyregion.parse(poly_reg)
-        mask = reg.get_mask(header=to_header(out_wcs), shape=out_sh)
+        reg = Regions.parse(poly_reg, format='ds9')[0]
+        mask = reg.to_mask().to_image(shape=out_sh)
 
     #yp, xp = np.indices(in_data.shape)
     #xi, yi = xp[mask], yp[mask]

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -383,7 +383,7 @@ def blot_nearest_exact(in_data, in_wcs, out_wcs, verbose=True, stepsize=-1,
         mask = out_xy_path.contains_points(pts).reshape(out_sh)
     else:
         olap_poly = np.array(olap.exterior.xy)
-        poly_reg = "fk5\npolygon("+','.join(['{0}'.format(p) for p in olap_poly.T.flatten()])+')\n'
+        poly_reg = "fk5\npolygon("+','.join(['{0}'.format(p + 1) for p in olap_poly.T.flatten()])+')\n'
         reg = pyregion.parse(poly_reg)
         mask = reg.get_mask(header=to_header(out_wcs), shape=out_sh)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     numpy
     peakutils
     # pyia
-    pyregion
+    regions
     scikit-image
     scikit-learn
     scipy
@@ -63,12 +63,12 @@ aws =
     boto3
     psycopg2-binary
     sqlalchemy
-hst = 
+hst =
     reprocess-wfc3
     astroscrappy
     drizzlepac
     stsci.tools
-    
+
 [options.package_data]
 grizli.data =
     *.yml


### PR DESCRIPTION
This PR converts the code to use the `regions` package instead of `pyregion`.  While doing so, I also fixed a couple of indexing bugs (ds9 regions are always 1-indexed).

Followup to #127.

CC: @jdavies-st 