### PR TITLE
Add updated NIRCam LW bad pixel table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ grizli/data/templates/*.npy
 *notes
 PipelineTest/*
 
+*DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
(From https://github.com/gbrammer/grizli/commit/fc8b0ffebdb870bf7e3c6455338dff021517c79a, which was committed to the master branch.)

A bunch of hot pixels seem to have appeared since I originally made the sky flats.  This update includes the new bad pixel files 

```
grizli/data/nrc_badpix_230120_NRCALONG.fits.gz
grizli/data/nrc_badpix_230120_NRCBLONG.fits.gz
```

The masks are applied when making mosaics with `grizli.aws.cutout_mosaic`, which calls `grizli.utils.drizzle_from_visit`.
