### PR TITLE
Adding second pass median subtraction for grism spectra

### DIFF
--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -1158,7 +1158,7 @@ class GroupFLT():
             flt.grism.header['BKGBH'] = bh, 'sep background bh'
 
 
-    def subtract_median_filter(self, filter_size=71, filter_central=10, revert=True, second_pass_filtering=False, box_filter_sn=3, box_filter_width=3):
+    def subtract_median_filter(self, filter_size=71, filter_central=10, revert=True, filter_footprint=None, subtract_model=False, second_pass_filtering=False, box_filter_sn=3, box_filter_width=3):
         """
         Remove a median filter calculated along the dispersion axis
         """

--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -1158,7 +1158,7 @@ class GroupFLT():
             flt.grism.header['BKGBH'] = bh, 'sep background bh'
 
 
-    def subtract_median_filter(self, filter_size=71, filter_central=10, revert=True, filter_footprint=None, subtract_model=False):
+    def subtract_median_filter(self, filter_size=71, filter_central=10, revert=True, second_pass_filtering=False, box_filter_sn=3, box_filter_width=3):
         """
         Remove a median filter calculated along the dispersion axis
         """
@@ -1213,6 +1213,33 @@ class GroupFLT():
                                                footprint=filter_footprint)
                 
                 filter_sci[~np.isfinite(filter_sci)] = 0
+
+            if second_pass_filtering==True:
+                if nbutils is None:
+                    # need numba installed
+                    utils.log_comment(utils.LOGFILE, 'skipping second pass filtering. Need numba library installed', verbose=True)
+                else:
+                    # run filter again, but mask pixels that show significant residuals (e.g. strong emission lines)
+                    utils.log_comment(utils.LOGFILE, f'rerunning filtering and masking S/N>{box_filter_sn} pixels in residual', verbose=True)
+
+                    # first do some binning/box filtering to identify significantly detected lines in individual exposures
+                    box_filter_footprint = np.ones((box_filter_width,box_filter_width), dtype=int)
+                    box_filter_clean = nd.generic_filter(sci_i-filter_sci,
+                                                    nbutils.nansum,
+                                                    footprint=box_filter_footprint)
+                    box_filter_err = box_filter_width*nd.generic_filter(err_i,
+                                                    nbutils.nanmean,
+                                                    footprint=box_filter_footprint)                                                
+
+                    # mask pixels that have S/N>filter_sn after median filtering
+                    okmask = (ok) & ~(box_filter_clean/box_filter_err > box_filter_sn)
+                    
+                    sci_i[~okmask] = np.nan
+                    filter_sci = nd.generic_filter(sci_i,
+                                                nbutils.nanmedian,
+                                                footprint=filter_footprint[None,:])
+                    
+                    filter_sci[~np.isfinite(filter_sci)] = 0   
                 
             flt.grism.data['SCI'] -= filter_sci*ok
             flt.grism.data['MED'] = filter_sci*ok

--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -1214,7 +1214,7 @@ class GroupFLT():
                 
                 filter_sci[~np.isfinite(filter_sci)] = 0
 
-            if second_pass_filtering==True:
+            if second_pass_filtering:
                 if nbutils is None:
                     # need numba installed
                     utils.log_comment(utils.LOGFILE, 'skipping second pass filtering. Need numba library installed', verbose=True)

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -2944,7 +2944,7 @@ def load_GroupFLT(field_root='j142724+334246', PREP_PATH='../Prep', force_ref=No
         return [grp]
 
 
-def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='../Extractions', ds9=None, refine_niter=3, gris_ref_filters=GRIS_REF_FILTERS, force_ref=None, files=None, split_by_grism=True, refine_poly_order=1, refine_fcontam=0.5, cpu_count=0, mask_mosaic_edges=True, prelim_mag_limit=25, refine_mag_limits=[18, 24], init_coeffs=[1.1, -0.5], grisms_to_process=None, pad=(64, 256), model_kwargs={'compute_size': True}, sep_background_kwargs=None, subtract_median_filter=False, median_filter_size=71, median_filter_central=10):
+def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='../Extractions', ds9=None, refine_niter=3, gris_ref_filters=GRIS_REF_FILTERS, force_ref=None, files=None, split_by_grism=True, refine_poly_order=1, refine_fcontam=0.5, cpu_count=0, mask_mosaic_edges=True, prelim_mag_limit=25, refine_mag_limits=[18, 24], init_coeffs=[1.1, -0.5], grisms_to_process=None, pad=(64, 256), model_kwargs={'compute_size': True}, sep_background_kwargs=None, subtract_median_filter=False, median_filter_size=71, median_filter_central=10, second_pass_filtering=False, box_filter_sn=3, box_filter_width=3):
     """
     Contamination model for grism exposures
     """
@@ -2982,7 +2982,8 @@ def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='.
             # and don't do any contamination modeling
             refine_niter = 0
             grp.subtract_median_filter(filter_size=median_filter_size, 
-                                       filter_central=median_filter_central)
+                                       filter_central=median_filter_central,
+                                       second_pass_filtering=second_pass_filtering, box_filter_sn=box_filter_sn, box_filter_width=box_filter_width)
             
         else:
             ################

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -2983,7 +2983,9 @@ def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='.
             refine_niter = 0
             grp.subtract_median_filter(filter_size=median_filter_size, 
                                        filter_central=median_filter_central,
-                                       second_pass_filtering=second_pass_filtering, box_filter_sn=box_filter_sn, box_filter_width=box_filter_width)
+                                       second_pass_filtering=second_pass_filtering, 
+                                       box_filter_sn=box_filter_sn, 
+                                       box_filter_width=box_filter_width)
             
         else:
             ################


### PR DESCRIPTION
Added functionality to do a second pass median subtraction after masking pixels with significant flux (e.g. emission lines) in the first pass. This ameliorates self-subtraction of lines.
Code could potentially be improved by using a convolution rather than box filtering for binned S/N estimates. 