### PR TITLE
Do flat-field before full 1/f correction

### DIFF
--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -125,6 +125,7 @@ visit_prep_args: &prep_args
         thresholds: [5,4,3]
         dilate_iterations: 3
         deg_pix: 64
+        other_axis: False
     snowball_kwargs:
         snowball_erode: 4
         snowball_dilate: 18

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -5470,15 +5470,15 @@ def get_photom_scale(header):
                              'data/photom_correction.yml')
     
     if not os.path.exists(corr_file):
+        print(f'{corr_file} not found.')
         return None, 1
     
     with open(corr_file) as fp:
         corr = yaml.load(fp, Loader=yaml.SafeLoader)
-    
-    print(header['CRDS_CTX'], corr['CRDS_CTX_MAX'], corr_file)
-    
+        
     if 'CRDS_CTX' in header:
         if header['CRDS_CTX'] > corr['CRDS_CTX_MAX']:
+            print(f"{corr_file}: {header['CRDS_CTX']} > {corr['CRDS_CTX_MAX']}")
             return header['CRDS_CTX'], 1.0
             
     key = '{0}-{1}'.format(header['DETECTOR'], header['FILTER'])
@@ -5486,9 +5486,11 @@ def get_photom_scale(header):
         key += '-{0}'.format(header['PUPIL'])
     
     if key not in corr:
+        print(f"{corr_file}: {key} not specified")
         return key, 1.0
     
     else:
+        print(f"{corr_file}: Scale {key} by {1./corr[key]:.3f}")
         return key, 1./corr[key]
 
 

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -5462,6 +5462,7 @@ def get_photom_scale(header):
     import yaml
     if 'TELESCOP' in header:
         if header['TELESCOP'] not in ['JWST']:
+            print(f"{corr_file}: TELESCOP={header['TELESCOP']} is not 'JWST'")
             return header['TELESCOP'], 1.0
     else:
         return None, 1.0

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -5462,7 +5462,7 @@ def get_photom_scale(header):
     import yaml
     if 'TELESCOP' in header:
         if header['TELESCOP'] not in ['JWST']:
-            print(f"{corr_file}: TELESCOP={header['TELESCOP']} is not 'JWST'")
+            print(f"get_photom_scale: TELESCOP={header['TELESCOP']} is not 'JWST'")
             return header['TELESCOP'], 1.0
     else:
         return None, 1.0
@@ -5479,7 +5479,7 @@ def get_photom_scale(header):
         
     if 'CRDS_CTX' in header:
         if header['CRDS_CTX'] > corr['CRDS_CTX_MAX']:
-            print(f"{corr_file}: {header['CRDS_CTX']} > {corr['CRDS_CTX_MAX']}")
+            print(f"get_photom_scale {corr_file}: {header['CRDS_CTX']} > {corr['CRDS_CTX_MAX']}")
             return header['CRDS_CTX'], 1.0
             
     key = '{0}-{1}'.format(header['DETECTOR'], header['FILTER'])
@@ -5487,11 +5487,11 @@ def get_photom_scale(header):
         key += '-{0}'.format(header['PUPIL'])
     
     if key not in corr:
-        print(f"{corr_file}: {key} not specified")
+        print(f"get_photom_scale {corr_file}: {key} not found")
         return key, 1.0
     
     else:
-        print(f"{corr_file}: Scale {key} by {1./corr[key]:.3f}")
+        print(f"get_photom_scale {corr_file}: Scale {key} by {1./corr[key]:.3f}")
         return key, 1./corr[key]
 
 


### PR DESCRIPTION
The aggressive 1/f correction with `deg_pix=2048` removes gradients that are then not flat-fielded correctly.  This update checks to see if the aggressive 1/f correction is requested, and if so, does the flat-field calibration *before* the 1/f correction.  

Also implemented is an optional keyword `other_axis` that if specified will also result in a correction calculated across the second detector axis.