### PR TITLE
Update utils.py

### DIFF
--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -2,6 +2,7 @@
 Dumping ground for general utilities
 """
 import os
+import shutil
 import glob
 import inspect
 from collections import OrderedDict
@@ -6133,7 +6134,7 @@ def symlink_templates(force=False):
 
     if (not os.path.exists(out_path)) | force:
         if os.path.exists(out_path):  # (force)
-            os.remove(out_path)
+            shutil.rmtree(out_path)
 
             os.symlink(templates_path, out_path)
             print('Symlink: {0} -> {1}'.format(templates_path, out_path))


### PR DESCRIPTION
os.remove() only removes a selected file, though the code expects the removal of a directory. os.rmdir() is not a suitable substitute since /templates could contain files.