### PR TITLE
Functions for subtracting column averages along rotated axes for NIRCam star spikes

### DIFF
--- a/grizli/aws/lambda_handler.py
+++ b/grizli/aws/lambda_handler.py
@@ -814,13 +814,17 @@ def run_grizli_fit(event):
             grizli_db.add_redshift_fit_row(rowfile, table=dbtable,
                                            verbose=True)
 
+    except:
+        print('Update row failed')
+        pass
+    
+    try:
         # Add 1D spectra
         files = glob.glob('{0}_{1:05d}*1D.fits'.format(root, id))
         if (len(files) > 0) & (dbtable == 'redshift_fit_v2'):
             grizli_db.send_1D_to_database(files=files)
-
     except:
-        print('Update row failed')
+        print(f'send_1D_to_database {files} failed')
         pass
 
     # Remove start log now that done

--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -1343,6 +1343,7 @@ def process_visit(assoc, clean=True, sync=True, max_dt=4, combine_same_pa=False,
                   --include "Prep/*s.log" \
                   --include "Prep/*visits.*" \
                   --include "Prep/*skyflat.*" \
+                  --include "Prep/*angles.*" \
                   --include "*fail*" \
                   --include "RAW/*[nx][tg]" """
         

--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -131,6 +131,13 @@ visit_prep_args: &prep_args
         snowball_dilate: 18
         mask_bit: 1024
         instruments: [NIRCAM, NIRISS]
+    angle_background_kwargs:
+        threshold: 1.8
+        detection_background: True
+        angles: [30.0, -30.0, 0, 90]
+        suffix: 'angles'
+        niter: 3
+        instruments: []
     miri_skyflat: False
     miri_skyfile: null
     use_skyflats: True


### PR DESCRIPTION
Some NIRCam visits appear to show diffraction spikes from *very* bright stars that are as much as a few degrees away from the target field (e.g., the star Mira in PRIMER UDS).  This PR includes functions to compute column averages of combined images rotated with respect to the ``PA_APER`` instrument position angle.  The main off-axis diffraction spikes for NIRCam are at PA_APER±30 deg.

To turn this on, run the processing pipeline with, e.g., 

```python
>>> visit_processor.process_visit(assoc,
                                  prep_args={'angle_background_kwargs':
                                                  {'instruments': ['NIRCAM'],
                                                   'niter':3, 'threshold':1.8,
                                                   }
                                  })
```
This PR also implements looking for a ``BKG`` extension in the exposure files when making a mosaic, so that any derived background can be kept separate from the ``SCI`` arrays.