### PR TITLE
Enable additional stretches in `auto_script.field_rgb` with `astropy.visualization.simple_norm`

### DIFF
--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -4502,13 +4502,19 @@ def process_direct_grism_visit(direct={},
             subtract_visit_angle_averages(direct, **angle_background_kwargs)
         
         # Remake final mosaic
-        _ = drizzle_from_visit(direct, output=None, pixfrac=1., kernel='point',
-                               clean=False, include_saturated=True, 
-                               keep_bits=None, dryrun=False, skip=None,
-                               extra_wfc3ir_badpix=True,
-                               verbose=False,
-                               scale_photom=False,
-                               calc_wcsmap=False)
+        _ = utils.drizzle_from_visit(direct,
+                                     output=None,
+                                     pixfrac=1.,
+                                     kernel='point',
+                                     clean=False,
+                                     include_saturated=True, 
+                                     keep_bits=None,
+                                     dryrun=False,
+                                     skip=None,
+                                     extra_wfc3ir_badpix=True,
+                                     verbose=False,
+                                     scale_photom=False,
+                                     calc_wcsmap=False)
                        
         _sci, _wht, _hdr, _files, _info = _
         _drcfile = glob.glob(f"{direct['product']}_dr*sci.fits")[0]

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -4492,16 +4492,39 @@ def process_direct_grism_visit(direct={},
         
         if run_separate_chip_sky & isACS:
             separate_chip_sky(direct, **separate_chip_kwargs)
-            
-        # Chip-level background for some UVIS filters
-        #  uvis_chip_background(visit=direct)
+        
+        # Reset JWST headers
+        if isJWST:
+            for file in direct['files']:
+                _ = jwst_utils.set_jwst_to_hst_keywords(file, reset=True)
+        
+        if angle_background_kwargs:
+            subtract_visit_angle_averages(direct, **angle_background_kwargs)
+        
+        # Remake final mosaic
+        _ = drizzle_from_visit(direct, output=None, pixfrac=1., kernel='point',
+                               clean=False, include_saturated=True, 
+                               keep_bits=None, dryrun=False, skip=None,
+                               extra_wfc3ir_badpix=True,
+                               verbose=False,
+                               scale_photom=False,
+                               calc_wcsmap=False)
+                       
+        _sci, _wht, _hdr, _files, _info = _
+        _drcfile = glob.glob(f"{direct['product']}_dr*sci.fits")[0]
+        _whtfile = _drcfile.replace('_sci.fits','_wht.fits')
+        pyfits.PrimaryHDU(data=_sci, header=_hdr).writeto(_drcfile,
+                                                          overwrite=True)
+        pyfits.PrimaryHDU(data=_wht, header=_hdr).writeto(_whtfile,
+                                                          overwrite=True)
         
         # Remake catalog
         #cat = make_drz_catalog(root=direct['product'], threshold=thresh)
         cat = make_SEP_catalog(root=direct['product'], threshold=thresh)
 
         # 140 brightest or mag range
-        clip = (cat['MAG_AUTO'] > align_mag_limits[0]) & (cat['MAG_AUTO'] < align_mag_limits[1])
+        clip = (cat['MAG_AUTO'] > align_mag_limits[0])
+        clip &= (cat['MAG_AUTO'] < align_mag_limits[1])
         if len(align_mag_limits) > 2:
             clip &= cat['MAGERR_AUTO'] < align_mag_limits[2]
         else:
@@ -4517,25 +4540,15 @@ def process_direct_grism_visit(direct={},
         if clip.sum() > NMAX:
             so = so[:NMAX]
 
-        table_to_regions(cat[clip][so], 
-                         '{0}.cat.reg'.format(direct['product']))
+        table_to_regions(cat[clip][so], f"{direct['product']}.cat.reg")
 
         if not ((isACS | isWFPC2) & is_single):
-            table_to_radec(cat[clip][so], 
-                           '{0}.cat.radec'.format(direct['product']))
+            table_to_radec(cat[clip][so], f"{direct['product']}.cat.radec")
 
         if (fix_stars) & (not isACS) & (not isWFPC2) & (not isJWST):
             fix_star_centers(root=direct['product'], drizzle=False, 
                              mag_lim=19.5)
         
-        # Reset JWST headers
-        if isJWST:
-            for file in direct['files']:
-                _ = jwst_utils.set_jwst_to_hst_keywords(file, reset=True)
-        
-        if angle_background_kwargs:
-            subtract_visit_angle_averages(direct, **angle_background_kwargs)
-    
     #################
     # Grism image processing
     #################

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -5622,12 +5622,14 @@ def drizzle_from_visit(visit, output=None, pixfrac=1., kernel='point',
     count = 0
 
     ref_photflam = None
-
+    
     indices = []
-
     for i in range(len(visit['files'])):
-        olap = visit['footprints'][i].intersection(output_poly)
-        if olap.area > 0:
+        if 'footprints' in visit:
+            olap = visit['footprints'][i].intersection(output_poly)
+            if olap.area > 0:
+                indices.append(i)
+        else:
             indices.append(i)
 
     if skip is not None:

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -5127,7 +5127,7 @@ def make_maximal_wcs(files, pixel_scale=None, get_hdu=True, pad=90, verbose=True
                     wcs_list.append((wcs, file, ext))
     
     if pixel_scale is None:
-        pixel_scale = get_wcs_pscale(wcs_list[0])
+        pixel_scale = get_wcs_pscale(wcs_list[0][0])
         
     group_poly = None
     for i, (wcs, file, chip) in enumerate(wcs_list):
@@ -5605,10 +5605,11 @@ def drizzle_from_visit(visit, output=None, pixfrac=1., kernel='point',
     elif isinstance(output, PrimaryHDU) | isinstance(output, ImageHDU):
         outputwcs = pywcs.WCS(output.header)
     elif output is None:
-        _header, outputwcs = make_maximal_wcs(files=visit['files'],
-                                              pixel_scale=None,
-                                              get_hdu=False,
-                                              verbose=False)
+        _hdu = make_maximal_wcs(files=visit['files'],
+                                pixel_scale=None,
+                                get_hdu=True,
+                                verbose=False)
+        outputwcs = pywcs.WCS(_hdu.header)
     else:
         return None
 

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -5608,7 +5608,8 @@ def drizzle_from_visit(visit, output=None, pixfrac=1., kernel='point',
         _hdu = make_maximal_wcs(files=visit['files'],
                                 pixel_scale=None,
                                 get_hdu=True,
-                                verbose=False)
+                                verbose=False,
+                                pad=4)
         outputwcs = pywcs.WCS(_hdu.header)
     else:
         return None


### PR DESCRIPTION
For example, 

```python
ASINH_NORM =  {'stretch': 'asinh',
               'min_cut': -0.02, 'max_cut': 1.0, 
               'clip':True, 'asinh_a':0.03}

grizli.pipeline.auto_script.field_rgb(..., norm_kwargs=ASINH_NORM)
```
