### PR TITLE
Update `jwst_level1` script with option to just modify the `jump` DQ flags

### DIFF
--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -7,6 +7,9 @@ PERSIST_PATH: null
 EXTRACT_PATH: null
 CRDS_CONTEXT: null
 
+min_gaia_count: 128
+gaia_mag_limits: [16,20.5,0.05]
+
 filters: &filters 
     [F410M, F467M, F547M, F550M, F621M, F689M, F763M, F845M, F200LP, F350LP,
      F435W, F438W, F439W, F450W, F475W, F475X, F555W, F569W, F600LP, F606W,
@@ -30,6 +33,7 @@ fetch_files_args:
     s3path: null
     force_rate: True
     get_rateints: False
+    recalibrate_jwst: False
     inst_products: 
         ACS/WFC: [FLC]
         WFC3/IR: [RAW]


### PR DESCRIPTION
Do own identification of "snowball" artifacts in the group-level products from the pipeline `jump` step, then run `ramp` on the modified `jump` products.  This is more robust than the earlier script that tried to roll a full ramp fit and with resulting uncertainties.

This PR also includes a function `grizli.catalog.gaia_catalog_for_assoc` to query the GAIA DR3 catalog for overlaps with a given association.  If enough sources are found (`auto_script.go.min_gaia_count=128`), then use the GAIA catalog as the master reference list.