### PR TITLE
Force grismconf==1.32

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ docs =
 jwst =
     jwst
     pysiaf
-    grismconf
+    grismconf==1.32
     numba
     drizzlepac
 aws =


### PR DESCRIPTION
Set `grismconf==1.32` requirement for back-compatibility with previously-saved grizli `GrismFLT` files.