### PR TITLE
Implement additional mosaic weight strategies

### DIFF
--- a/grizli/aws/aws_drizzler.py
+++ b/grizli/aws/aws_drizzler.py
@@ -782,7 +782,14 @@ def drizzle_images(label='macs0647-jd1', ra=101.9822125, dec=70.24326667, pixsca
         else:
             clean_i = remove
 
-        status = utils.drizzle_from_visit(visits[0], h, pixfrac=pixfrac, kernel=kernel, clean=clean_i, include_saturated=include_saturated, skip=skip, dryrun=dryrun)
+        status = utils.drizzle_from_visit(visits[0],
+                                          h,
+                                          pixfrac=pixfrac, kernel=kernel, 
+                                          clean=clean_i, 
+                                          include_saturated=include_saturated,
+                                          weight_type='median_err',
+                                          skip=skip,
+                                          dryrun=dryrun)
 
         if dryrun:
             filt_dict[filt] = status

--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -1716,7 +1716,7 @@ def query_exposures(ra=53.16, dec=-27.79, size=1., pixel_scale=0.1, theta=0,  fi
     return header, wcs, SQL, res
 
 
-def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-27.7910651, size=5*60, theta=0., filters=['F160W'], ir_scale=0.1, ir_wcs=None, res=None, half_optical=True, kernel='point', pixfrac=0.33, make_figure=True, skip_existing=True, clean_flt=True, gzip_output=True, s3output='s3://grizli-v2/HST/Pipeline/Mosaic/', split_uvis=True, extra_query='', extra_wfc3ir_badpix=True, fix_niriss=True, scale_nanojy=10, verbose=True, weight_type='median_err', niriss_ghost_kwargs={}, scale_photom=True, calc_wcsmap=False, **kwargs):
+def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-27.7910651, size=5*60, theta=0., filters=['F160W'], ir_scale=0.1, ir_wcs=None, res=None, half_optical=True, kernel='point', pixfrac=0.33, make_figure=True, skip_existing=True, clean_flt=True, gzip_output=True, s3output='s3://grizli-v2/HST/Pipeline/Mosaic/', split_uvis=True, extra_query='', extra_wfc3ir_badpix=True, fix_niriss=True, scale_nanojy=10, verbose=True, weight_type='err', niriss_ghost_kwargs={}, scale_photom=True, calc_wcsmap=False, **kwargs):
     """
     Make mosaic from exposures defined in the exposure database
     

--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -1716,15 +1716,99 @@ def query_exposures(ra=53.16, dec=-27.79, size=1., pixel_scale=0.1, theta=0,  fi
     return header, wcs, SQL, res
 
 
-def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-27.7910651, size=5*60, theta=0., filters=['F160W'], ir_scale=0.1, ir_wcs=None, res=None, half_optical=True, kernel='point', pixfrac=0.33, make_figure=True, skip_existing=True, clean_flt=True, gzip_output=True, s3output='s3://grizli-v2/HST/Pipeline/Mosaic/', split_uvis=True, extra_query='', extra_wfc3ir_badpix=True, fix_niriss=True, scale_nanojy=10, verbose=True, niriss_ghost_kwargs={}, scale_photom=True, calc_wcsmap=False, **kwargs):
+def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-27.7910651, size=5*60, theta=0., filters=['F160W'], ir_scale=0.1, ir_wcs=None, res=None, half_optical=True, kernel='point', pixfrac=0.33, make_figure=True, skip_existing=True, clean_flt=True, gzip_output=True, s3output='s3://grizli-v2/HST/Pipeline/Mosaic/', split_uvis=True, extra_query='', extra_wfc3ir_badpix=True, fix_niriss=True, scale_nanojy=10, verbose=True, weight_type='median_err', niriss_ghost_kwargs={}, scale_photom=True, calc_wcsmap=False, **kwargs):
     """
     Make mosaic from exposures defined in the exposure database
     
     Parameters
     ----------
+    rootname : str
+        Output file rootname
+    
+    product : str
+        File name structure that will be parsed with ``product.format(rootname, f)``,
+        where ``f`` is the filter name
+    
+    ra, dec : float
+        Cutout center in decimal degrees
+    
+    size : float
+        Cutout size in arcsec
+    
+    theta : float
+        Position angle of the output WCS
+    
+    filters : list
+        List of filter names to use for the mosaic.
+    
+    ir_scale : float
+        Pixel scale in arcsec
+    
+    ir_wcs : `~astropy.wcs.WCS`
+        Specify the output WCS explicitly rather than deriving from
+        ``ra, dec, size, theta``.
+    
+    res : None, `~astropy.table.Table`
+        Explicit list of exposure file metadata, e.g., from 
+        `~grizli.aws.visit_processor.res_query_from_local`.  If not specified, the 
+        grizli-processed exposures that overlap with the requested cutout WCS will be
+        determined by querying the `grizli` database (`~grizli.aws.db`).
+    
+    half_optical : bool
+        Use WCS with pixels 2x smaller than defined in `ir_wcs` for ACS/WFC, WFC3/UVIS,
+        NIRCam and NIRISS filters.
+    
+    kernel, pixfrac : str, float
+        Drizzle parameters
+    
+    skip_existing : bool
+        Skip `product` combinations already found in the working directory
+    
+    clean_flt : bool
+        Remove exposures one-by-one after they have been added to the cutout / mosaic.
+    
+    gzip_output : bool
+        Compress the output files after completion
+    
+    s3output : str
+        Path name of an AWS S3 bucket where products will be sent upon completion
+    
+    split_uvis : bool
+        Make separate mosaics for ACS/WFC and WFC3/UVIS filters with the same name
+    
+    extra_query : str
+        Extra SQL query criteria added to the DB query if ``res`` not provided
+    
+    extra_wfc3ir_badpix : str
+        Add additional bad pixel mask for WFC3/IR and NIRCam from the bad pixel files 
+        provided in `grizli.data`.
+    
+    fix_niriss : bool
+        Separate filter names for NIRISS
+    
+    scale_nanojy : bool
+        Photometric scale of the output image, i.e., a pixel value of one corresponds
+        to a flux density of `scale_nanojy` nJy per pix.
+    
+    verbose : bool
+        Verbose messaging
+    
+    weight_type : 'median_err', 'err'
+        Drizzle weight strategy (see `~grizli.utils.drizzle_from_visit`)
+    
+    niriss_ghost_kwargs : dict
+        Parameters of the NIRISS ghost flagging
+    
+    scale_photom : bool
+        See `~grizli.utils.drizzle_from_visit`
+    
+    calc_wcsmap : bool
+        See `~grizli.utils.drizzle_from_visit`
     
     Returns
     -------
+    Image mosaic files with the requested WCS and filters
+    
     """
     import os
     import glob
@@ -1895,6 +1979,7 @@ def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-
                                      verbose=verbose,
                                      scale_photom=scale_photom,
                                      niriss_ghost_kwargs=niriss_ghost_kwargs,
+                                     weight_type=weight_type,
                                      calc_wcsmap=calc_wcsmap)
                              
         outsci, outwht, header, flist, wcs_tab = _
@@ -2090,7 +2175,7 @@ def show_epochs_filter(ra, dec, size=4, filter='F444W-CLEAR', cleanup=True, vmax
     return fig
 
 
-def make_mosaic(jname='', ds9=None, skip_existing=True, ir_scale=0.1, half_optical=False, pad=16, kernel='point', pixfrac=0.33, sync=True, ir_wcs=None):
+def make_mosaic(jname='', ds9=None, skip_existing=True, ir_scale=0.1, half_optical=False, pad=16, kernel='point', pixfrac=0.33, sync=True, ir_wcs=None, weight_type='median_err'):
     """
     Make mosaics from all exposures in a group of associations
     """
@@ -2267,7 +2352,9 @@ def make_mosaic(jname='', ds9=None, skip_existing=True, ir_scale=0.1, half_optic
             
         _ = utils.drizzle_from_visit(groups[f], groups[f]['reference'], 
                                      pixfrac=pixfrac, 
-                                     kernel=kernel, clean=False)
+                                     kernel=kernel, clean=False,
+                                     weight_type=weight_type,
+                                     )
                              
         outsci, outwht, header, flist, wcs_tab = _
     

--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -102,7 +102,7 @@ visit_prep_args: &prep_args
     drizzle_params: {}
     single_image_CRs: True
     run_tweak_align: True
-    tweak_threshold: 1.5
+    tweak_threshold: 3.0
     tweak_fit_order: -1
     tweak_max_dist: 100
     tweak_n_min: 10

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -3519,6 +3519,7 @@ def subtract_visit_angle_averages(visit, threshold=1.8, detection_background=Tru
                                        clean=False,
                                        verbose=False,
                                        scale_photom=False,
+                                       weight_type='median_err',
                                       )
         drz_h = drz[2]
 
@@ -4506,7 +4507,9 @@ def process_direct_grism_visit(direct={},
                                      extra_wfc3ir_badpix=True,
                                      verbose=False,
                                      scale_photom=False,
-                                     calc_wcsmap=False)
+                                     weight_type='median_err',
+                                     calc_wcsmap=False,
+                                     )
                        
         _sci, _wht, _hdr, _files, _info = _
         _drcfile = glob.glob(f"{direct['product']}_dr*sci.fits")[0]


### PR DESCRIPTION
A number of JWST collaborations have been identifying similar issues with the stellar curves of growth in image mosaics produced with the `grizli` pipeline, i.e., that the short wavelength CoG looked too broad in the `grizli` mosaics compared to others made with the JWST pipeline.  I've come across a couple of points that were quite surprising and still a bit mysterious.

1. The first is that the "tweakshifts" alignment I'm doing in grizli for the short wavelength filters may not be as precise as assumed.  These shifts are occasionally of order 0.5 pix, but the alignment reports error-of-the-mean RMS values of 0.1-0.2 pix.  I had thought that was standard deviation ~0.1 pix, which would be much smaller with sqrt(N).  But in fact, at least for the F115W visit I checked the scatter in the alignment sources was truly of order 1 pix, or 0.1 pix on the mean.  I'm not quite sure why they could be so large, though perhaps could be related to PSF undersampling at the bluest wavelengths.  These alignment errors could have an effect on the derived stellar curves of growth if some fraction of the central bright pixels of stars were being flagged as CRs, though perhaps not necessarily in all exposures.

2. The second effect is more insidious and summarized in the plot below, which shows curves of growth measured in a) a mosaic with the nominal tweakshifts, b) a recomputed mosaic with the shift refinement turned off and c) all 16 individual exposures (from a F115W visit in UNCOVER).  The difference in the mosaics can perhaps be explained by the pixel flagging issues.  **A key point is that always looking at the curve of growth to diagnose the image quality could miss the key effect in that the main differences are in the central bright pixel or two, not necessarily in differences in the overall profile shape at larger radii.**  The mystery is in how the curves are quite different for the CoG in the individual exposures, where the central pixels are as much as 2-3x brighter than they are in the mosaics.  Since they contain a large fraction of the light, that then manifests as big differences in the overall normalization of the CoG, though the profiles at radii larger than the central few pixels are quite similar (the bottom panel is the diff of the CoG plotted above, measured with `sep`.

3. I'm not yet sure of the explanation for this latter effect, though I suspect it's related to the weighting used in the mosaic drizzling.  To make the mosaics, `grizli` converts the ERR extensions of the individual exposures to inverse variance weights, and these include a Poisson term for the detected photoelectrons, which can be quite high in the central bright pixels.  The JWST pipeline handles the variance components in a different way, which could explain why the differences are notable between my mosaics and others derived from the pipeline.

4. More tests TBD, but my suspicion is that these effects probably can explain a number of the strange CoG differences people have been finding, and also how some of them have brightness and filter dependencies.
![uncover_star_cog](https://github.com/gbrammer/grizli/assets/1577270/976a9e10-fd40-40f3-aacb-0d462efe8e6e)
