### PR TITLE
Implement using CRDS `specwcs` reference files directly for grism dispersions

### DIFF
--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -1017,7 +1017,7 @@ class TransformGrismconf(object):
             trace_dy += poly(x, y)
             # print(f'polynomial offset: {poly(x,y):.3f}')
             
-        elif ('V8/NIRCAM' in self.conf_file) | ('V8.5/NIRCAM' in self.conf_file):
+        elif ('V8/NIRCAM' in self.conf_file) | ('V8.5/NIRCAM' in self.conf_file) | ('V9/NIRCAM' in self.conf_file):
             #print('V8: do nothing')
             pass
             
@@ -1133,6 +1133,9 @@ def load_grism_config(conf_file, warnings=True):
         conf = TransformGrismconf(conf_file)
         conf.get_beams()
     elif 'V8.5/NIRCAM' in conf_file:
+        conf = TransformGrismconf(conf_file)
+        conf.get_beams()
+    elif 'V9/NIRCAM' in conf_file:
         conf = TransformGrismconf(conf_file)
         conf.get_beams()
     elif 'specwcs' in conf_file:

--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -1270,12 +1270,10 @@ class CRDSGrismConf():
         
         orders = []
         for o in self.dm.orders:
-            if o == 0:
-                orders.append('0')
-            elif o > 0:
+            if o > 0:
                 orders.append(f'+{o}')
-            elif o < 0:
-                orders.append(f'-{o}')
+            else:
+                orders.append(f'{o}')
         
         return orders
 
@@ -1358,7 +1356,9 @@ class CRDSGrismConf():
 
 
     def INVDISPL(self, order, x0, y0, dx, t0=np.linspace(-1, 2, 128), from_root=False):
-        """ Inverse DISPL """
+        """
+        Inverse DISPL
+        """
         if from_root:
             func = self._root_inverse_model
         else:
@@ -1368,12 +1368,23 @@ class CRDSGrismConf():
         t = func(self.dm.displ[io], x0, y0, dx, t0=t0)
         return t
 
-    
+
     def _eval_model(self, model, x0, y0, t, get_coeffs=False):
-        """General function for evaluating model polynomials"""
+        """
+        General function for evaluating model polynomials
+        """
         import numpy as np
         
-        if len(model) == 1:
+        if hasattr(model, 'n_inputs'):
+            if model.n_inputs == 1:
+                if get_coeffs:
+                    value = model.parameters[::-1]
+                else:
+                    value = model(t)
+            else:
+                value = model(x0, y0)
+        
+        elif len(model) == 1:
             if model[0].n_inputs == 1:
                 if get_coeffs:
                     value = model[0].parameters[::-1]

--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -1599,8 +1599,8 @@ class CRDSGrismConf():
             ix &= phot['pupil'] == self.pupil
             ix &= phot['order'] == self.dm.orders[i]
             if ix.sum() == 0:
-                msg = f"Order {order} = {dm.orders[i]} not found in {refs['photom']}"
-                msg += f" for {self.filter} {self.pupil}"
+                msg = f"Order {order} = {self.dm.orders[i]} not found in "
+                msg += f"{refs['photom']} for {self.filter} {self.pupil}"
                 print(msg)
                 continue
                 

--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -1280,7 +1280,11 @@ class CRDSGrismConf():
         
         self.full_path = full_path
         
-        self.dm = jwst.datamodels.NIRCAMGrismModel(full_path)
+        if 'nircam' in file:
+            self.dm = jwst.datamodels.NIRCAMGrismModel(full_path)
+        else:
+            self.dm = jwst.datamodels.NIRISSGrismModel(full_path)
+            
         self.SENS = None
         self.SENS_data = None
         

--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -1571,7 +1571,11 @@ class CRDSGrismConf():
             msg = f"Read photometry reference {refs['photom']} (date = '{date}')"
             print(msg)
             
-        ph = jwst.datamodels.NrcWfssPhotomModel(refs['photom'])
+        if self.instrument == 'NIRCAM':
+            ph = jwst.datamodels.NrcWfssPhotomModel(refs['photom'])
+        else:
+            ph = jwst.datamodels.NisWfssPhotomModel(refs['photom'])
+        
         phot = astropy.table.Table(ph.phot_table)
 
         pixel_area = ph.meta.photometry.pixelarea_steradians

--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -1225,11 +1225,17 @@ def load_grism_config(conf_file, warnings=True):
     return conf
 
 
-def crds_wfss_reffiles(instrument='NIRCAM', filter='F444W', pupil='GRISMR', module='A', date=None, reftypes=('photom', 'specwcs'), header=None):
+def crds_wfss_reffiles(instrument='NIRCAM', filter='F444W', pupil='GRISMR', module='A', date=None, reftypes=('photom', 'specwcs'), header=None, context='jwst_1123.pmap'):
     """
+    Get WFSS reffiles from CRDS
     """
     import astropy.time
     import crds
+    from . import jwst_utils
+    
+    if context is not None:
+        jwst_utils.CRDS_CONTEXT = context
+        jwst_utils.set_crds_context(verbose=False, override_environ=True)
     
     if header is not None:
         instrument = header['INSTRUME']
@@ -1270,11 +1276,37 @@ def crds_wfss_reffiles(instrument='NIRCAM', filter='F444W', pupil='GRISMR', modu
 
 
 class CRDSGrismConf():
-    def __init__(self, file='references/jwst/nircam/jwst_nircam_specwcs_0136.asdf', get_photom=True, **kwargs):
+    def __init__(self, file='references/jwst/nircam/jwst_nircam_specwcs_0136.asdf', get_photom=True, context='jwst_1123.pmap', **kwargs):
         """
         Helper object to replicate `grismconf` config files from CRDS products
+        
+        Parameters
+        ----------
+        file : str
+            Filename of a CRDS ``specwcs`` file
+        
+        get_photom : bool
+            Get sensitivity curves from the ``photom`` reference file
+        
+        context : str
+            Explicit CRDS_CONTEXT
+        
+        Attributes
+        ----------
+        dm : `jwst.datamodels.NIRCAMGrismModel`
+            DataModel of the ``specwcs`` reference
+        
+        SENS_data : dict
+            Sensitivity data like ``{order: (wave_microns, sensitity)}``
+        
         """
         import jwst.datamodels
+        from . import jwst_utils
+    
+        if context is not None:
+            jwst_utils.CRDS_CONTEXT = context
+            jwst_utils.set_crds_context(verbose=False, override_environ=True)
+
         self.file = file
         if file.startswith('references'):
             full_path = os.path.join(os.environ['CRDS_PATH'], file)

--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -1299,7 +1299,10 @@ class CRDSGrismConf():
 
     @property
     def module(self):
-        return self.dm.meta.instrument.module
+        if self.instrument == 'NIRCAM':
+            return self.dm.meta.instrument.module
+        else:
+            return None
 
 
     @property
@@ -1610,12 +1613,13 @@ class CRDSGrismConf():
             
             self.SENS_dldp[order] = dldp
             
-            sens_flam = (sens_fnu*dldp*u.megaJansky).to(u.erg/u.second/u.cm**2/u.micron,
-                            equivalencies=u.spectral_density(wave*u.micron))
+            mask = (wave > 0) & (sens_fnu > 0)
             
-            mask = (wave > 0) & (sens_flam > 0)
-            
-            self.SENS_data[order] = [wave[mask], 1./sens_flam[mask].value]
+            _flam_unit = u.erg/u.second/u.cm**2/u.micron
+            sens_flam = (sens_fnu[mask]*dldp*u.megaJansky).to(_flam_unit,
+                            equivalencies=u.spectral_density(wave[mask]*u.micron))
+                        
+            self.SENS_data[order] = [wave[mask], 1./sens_flam.value]
         
         return self.SENS_data
 

--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -1376,6 +1376,7 @@ class CRDSGrismConf():
         import numpy as np
         
         if hasattr(model, 'n_inputs'):
+            # model is a Polynomial
             if model.n_inputs == 1:
                 if get_coeffs:
                     value = model.parameters[::-1]
@@ -1385,6 +1386,7 @@ class CRDSGrismConf():
                 value = model(x0, y0)
         
         elif len(model) == 1:
+            # model is a single-element list, probably Polynomial1D
             if model[0].n_inputs == 1:
                 if get_coeffs:
                     value = model[0].parameters[::-1]
@@ -1394,6 +1396,7 @@ class CRDSGrismConf():
                 value = model[0](x0, y0)
             
         else:
+            # model is a list
             _c = []
             for m in model:
                 if m.n_inputs == 1:

--- a/grizli/jwst_utils.py
+++ b/grizli/jwst_utils.py
@@ -19,7 +19,8 @@ from . import GRIZLI_PATH
 QUIET_LEVEL = logging.INFO
 
 # CRDS_CONTEXT = 'jwst_0942.pmap' # July 29, 2022 with updated NIRCAM ZPs
-CRDS_CONTEXT = 'jwst_0995.pmap' # 2022-10-06 NRC ZPs and flats
+# CRDS_CONTEXT = 'jwst_0995.pmap' # 2022-10-06 NRC ZPs and flats
+CRDS_CONTEXT = 'jwst_1123.pmap' # 2023-09-08 NRC specwcs, etc.
 
 def set_crds_context(fits_file=None, override_environ=False, verbose=True):
     """
@@ -40,6 +41,10 @@ def set_crds_context(fits_file=None, override_environ=False, verbose=True):
         The value of the CRDS_CONTEXT environment variable
         
     """
+    from importlib import reload
+    import crds
+    import crds.core
+    import crds.core.heavy_client
     
     _CTX = CRDS_CONTEXT
     
@@ -55,6 +60,10 @@ def set_crds_context(fits_file=None, override_environ=False, verbose=True):
         
     msg = f"ENV CRDS_CONTEXT = {os.environ['CRDS_CONTEXT']}"
     utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
+    
+    # Need to reload CRDS modules to catch new CONTEXT
+    reload(crds.core); reload(crds); reload(crds.core.heavy_client)
+    
     return os.environ['CRDS_CONTEXT']
 
 

--- a/grizli/model.py
+++ b/grizli/model.py
@@ -2445,7 +2445,7 @@ class GrismFLT(object):
     def __init__(self, grism_file='', sci_extn=1, direct_file='',
                  pad=(64,256), ref_file=None, ref_ext=0, seg_file=None,
                  shrink_segimage=True, force_grism='G141', verbose=True,
-                 process_jwst_header=True):
+                 process_jwst_header=True, use_jwst_crds=False):
         """Read FLT files and, optionally, reference/segmentation images.
 
         Parameters
@@ -2638,10 +2638,17 @@ class GrismFLT(object):
         conf_args = dict(instrume=self.grism.instrument, 
                          filter=direct_filter, 
                          grism=self.grism.filter,
+                         pupil=self.grism.pupil,
                          module=self.grism.module,
-                         chip=self.grism.ccdchip)
+                         chip=self.grism.ccdchip,
+                         use_jwst_crds=use_jwst_crds)
         
-        self.conf_file = grismconf.get_config_filename(**conf_args)
+        if 'CONFFILE' in self.grism.header:
+            self.conf_file = self.grism.header['CONFFILE']
+        else:
+            self.conf_file = grismconf.get_config_filename(**conf_args)
+            self.grism.header['CONFFILE'] = self.conf_file
+            
         self.conf = grismconf.load_grism_config(self.conf_file)
 
         self.object_dispersers = OrderedDict()
@@ -4294,7 +4301,12 @@ class BeamCutout(object):
                              module=self.grism.module,
                              chip=self.grism.ccdchip)
             
-            self.conf_file = grismconf.get_config_filename(**conf_args)
+            if 'CONFFILE' in self.grism.header:
+                self.conf_file = self.grism.header['CONFFILE']
+            else:
+                self.conf_file = grismconf.get_config_filename(**conf_args)
+                self.grism.header['CONFFILE'] = self.conf_file
+            
             conf = grismconf.load_grism_config(self.conf_file)
 
         if 'GROW' in self.grism.header:

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -347,6 +347,7 @@ def go(root='j010311+131615',
        make_final_report=True,
        get_dict=False,
        kill='',
+       use_jwst_crds=False,
        **kwargs
        ):
     """
@@ -872,7 +873,8 @@ def go(root='j010311+131615',
         grp = multifit.GroupFLT(grism_files=grism_files, direct_files=[], 
                                 ref_file=None, seg_file=seg_file, 
                                 catalog=catalog, cpu_count=-1, sci_extn=1, 
-                                pad=(64,256))
+                                pad=(64,256),
+                                use_jwst_crds=use_jwst_crds)
 
         # Make drizzle model images
         grp.drizzle_grism_models(root=root, kernel='point', scale=0.15)
@@ -974,7 +976,8 @@ def go(root='j010311+131615',
         grp = multifit.GroupFLT(grism_files=grism_files, direct_files=[], 
                                 ref_file=None, seg_file=seg_file, 
                                 catalog=catalog, cpu_count=-1, sci_extn=1, 
-                                pad=(64,256))
+                                pad=(64,256),
+                                use_jwst_crds=use_jwst_crds)
 
         # Make drizzle model images
         grp.drizzle_grism_models(root=root, kernel='point', scale=0.15)
@@ -2991,7 +2994,7 @@ def photutils_catalog(field_root='j142724+334246', threshold=1.8, subtract_bkg=T
     return tab
 
 
-def load_GroupFLT(field_root='j142724+334246', PREP_PATH='../Prep', force_ref=None, force_seg=None, force_cat=None, galfit=False, pad=(64,256), files=None, gris_ref_filters=GRIS_REF_FILTERS, split_by_grism=False):
+def load_GroupFLT(field_root='j142724+334246', PREP_PATH='../Prep', force_ref=None, force_seg=None, force_cat=None, galfit=False, pad=(64,256), files=None, gris_ref_filters=GRIS_REF_FILTERS, split_by_grism=False, use_jwst_crds=False):
     """
     Initialize a GroupFLT object from exposures in a working directory.  The 
     script tries to match mosaic images with grism exposures based on the 
@@ -3181,7 +3184,8 @@ def load_GroupFLT(field_root='j142724+334246', PREP_PATH='../Prep', force_ref=No
                                   cpu_count=-1,
                                   sci_extn=1,
                                   pad=pad, 
-                                  polyx=polyx)
+                                  polyx=polyx,
+                                  use_jwst_crds=use_jwst_crds)
                                   
         grp_objects.append(grp_i)
 
@@ -3197,7 +3201,7 @@ def load_GroupFLT(field_root='j142724+334246', PREP_PATH='../Prep', force_ref=No
         return [grp]
 
 
-def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='../Extractions', ds9=None, refine_niter=3, gris_ref_filters=GRIS_REF_FILTERS, force_ref=None, files=None, split_by_grism=True, refine_poly_order=1, refine_fcontam=0.5, cpu_count=0, mask_mosaic_edges=False, prelim_mag_limit=25, refine_mag_limits=[18, 24], init_coeffs=[1.1, -0.5], grisms_to_process=None, pad=(64, 256), model_kwargs={'compute_size': True}, sep_background_kwargs=None, subtract_median_filter=False, median_filter_size=71, median_filter_central=10, second_pass_filtering=False, box_filter_sn=3, box_filter_width=3):
+def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='../Extractions', ds9=None, refine_niter=3, gris_ref_filters=GRIS_REF_FILTERS, force_ref=None, files=None, split_by_grism=True, refine_poly_order=1, refine_fcontam=0.5, cpu_count=0, mask_mosaic_edges=False, prelim_mag_limit=25, refine_mag_limits=[18, 24], init_coeffs=[1.1, -0.5], grisms_to_process=None, pad=(64, 256), model_kwargs={'compute_size': True}, sep_background_kwargs=None, subtract_median_filter=False, median_filter_size=71, median_filter_central=10, second_pass_filtering=False, box_filter_sn=3, box_filter_width=3, use_jwst_crds=False):
     """
     Contamination model for grism exposures
     """
@@ -3225,7 +3229,8 @@ def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='.
                                 files=files,
                                 split_by_grism=split_by_grism, 
                                 force_ref=force_ref,
-                                pad=pad)
+                                pad=pad,
+                                use_jwst_crds=use_jwst_crds)
 
     for grp in grp_objects:
         
@@ -3362,7 +3367,7 @@ DITHERED_PLINE = {'kernel': 'point', 'pixfrac': 0.2, 'pixscale': 0.1, 'size': 8,
 PARALLEL_PLINE = {'kernel': 'square', 'pixfrac': 1.0, 'pixscale': 0.1, 'size': 8, 'wcs': None}
 
 
-def refine_model_with_fits(field_root='j142724+334246', grp=None, master_files=None, spectrum='continuum', clean=True, max_chinu=5):
+def refine_model_with_fits(field_root='j142724+334246', grp=None, master_files=None, spectrum='continuum', clean=True, max_chinu=5, use_jwst_crds=False):
     """
     Refine the full-field grism models with the best fit spectra from 
     individual extractions.
@@ -3393,7 +3398,8 @@ def refine_model_with_fits(field_root='j142724+334246', grp=None, master_files=N
                                 catalog=catalog,
                                 cpu_count=-1,
                                 sci_extn=1,
-                                pad=(64,256))
+                                pad=(64,256),
+                                use_jwst_crds=use_jwst_crds)
 
     fit_files = glob.glob('*full.fits')
     fit_files.sort()
@@ -3441,7 +3447,7 @@ def refine_model_with_fits(field_root='j142724+334246', grp=None, master_files=N
     del(grp)
 
 
-def extract(field_root='j142724+334246', maglim=[13, 24], prior=None, MW_EBV=0.00, ids=[], pline=DITHERED_PLINE, fit_only_beams=True, run_fit=True, poly_order=7, oned_R=30, master_files=None, grp=None, bad_pa_threshold=None, fit_trace_shift=False, size=32, diff=True, min_sens=0.02, fcontam=0.2, min_mask=0.01, sys_err=0.03, skip_complete=True, fit_args={}, args_file='fit_args.npy', get_only_beams=False):
+def extract(field_root='j142724+334246', maglim=[13, 24], prior=None, MW_EBV=0.00, ids=[], pline=DITHERED_PLINE, fit_only_beams=True, run_fit=True, poly_order=7, oned_R=30, master_files=None, grp=None, bad_pa_threshold=None, fit_trace_shift=False, size=32, diff=True, min_sens=0.02, fcontam=0.2, min_mask=0.01, sys_err=0.03, skip_complete=True, fit_args={}, args_file='fit_args.npy', get_only_beams=False, use_jwst_crds=False):
     import glob
     import os
 
@@ -3475,8 +3481,8 @@ def extract(field_root='j142724+334246', maglim=[13, 24], prior=None, MW_EBV=0.0
                                 catalog=catalog,
                                 cpu_count=-1,
                                 sci_extn=1,
-                                pad=(64,256)
-                                )
+                                pad=(64,256),
+                                use_jwst_crds=use_jwst_crds)
     else:
         init_grp = False
 

--- a/grizli/tests/test_jwst.py
+++ b/grizli/tests/test_jwst.py
@@ -262,4 +262,28 @@ class TestJWSTFittingTools:
     #    if os.path.exists('wfc3-parse-test'):
     #        os.system('rm -rf wfc3-parse-test')
         
+class TestGrismConf:
     
+    def test_grismconf(self):
+        """
+        Test initializing ``grizli.grismconf.CRDSGrismConf``
+        """
+        import grizli.grismconf
+        
+        pytest.importorskip('jwst')
+        
+        refs = grizli.grismconf.crds_wfss_reffiles(instrument='NIRCAM',
+                                                   filter='F444W',
+                                                   pupil='GRISMR',
+                                                   module='A',
+                                                   date='2023-09-07 00:00:00',
+                                                   reftypes=('photom', 'specwcs'), 
+                                                   header=None, 
+                                                   context='jwst_1123.pmap')
+                                                   
+        assert('jwst_nircam_specwcs_0190' in refs['specwcs'])
+        
+        conf = grizli.grismconf.CRDSGrismConf(file=refs['specwcs'], get_photom=False)
+        
+        conf = grizli.grismconf.CRDSGrismConf(file=refs['specwcs'], get_photom=True)
+        


### PR DESCRIPTION
Helper functions in `grizli.grismconf` for using CRDS reference files to define the WFSS dispersion.