### PR TITLE
Compute photometry scaling factors for different CRDS_CONTEXT

### DIFF
--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -1772,7 +1772,7 @@ def query_exposures(ra=53.16, dec=-27.79, size=1., pixel_scale=0.1, theta=0,  fi
     return header, wcs, SQL, res
 
 
-def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-27.7910651, size=5*60, theta=0., filters=['F160W'], ir_scale=0.1, ir_wcs=None, res=None, half_optical=True, kernel='point', pixfrac=0.33, make_figure=True, skip_existing=True, clean_flt=True, gzip_output=True, s3output='s3://grizli-v2/HST/Pipeline/Mosaic/', split_uvis=True, extra_query='', extra_wfc3ir_badpix=True, fix_niriss=True, scale_nanojy=10, verbose=True, weight_type='err', rnoise_percentile=99, get_dbmask=True, niriss_ghost_kwargs={}, scale_photom=True, calc_wcsmap=False, make_exptime_map=False, expmap_sample_factor=4, keep_expmap_small=True, **kwargs):
+def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-27.7910651, size=5*60, theta=0., filters=['F160W'], ir_scale=0.1, ir_wcs=None, res=None, half_optical=True, kernel='point', pixfrac=0.33, make_figure=True, skip_existing=True, clean_flt=True, gzip_output=True, s3output='s3://grizli-v2/HST/Pipeline/Mosaic/', split_uvis=True, extra_query='', extra_wfc3ir_badpix=True, fix_niriss=True, scale_nanojy=10, verbose=True, weight_type='err', rnoise_percentile=99, get_dbmask=True, niriss_ghost_kwargs={}, scale_photom=True, context='jwst_0989.pmap', calc_wcsmap=False, make_exptime_map=False, expmap_sample_factor=4, keep_expmap_small=True, **kwargs):
     """
     Make mosaic from exposures defined in the exposure database
     
@@ -2043,6 +2043,7 @@ def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-
                                      extra_wfc3ir_badpix=extra_wfc3ir_badpix,
                                      verbose=verbose,
                                      scale_photom=scale_photom,
+                                     context=context,
                                      get_dbmask=get_dbmask,
                                      niriss_ghost_kwargs=niriss_ghost_kwargs,
                                      weight_type=weight_type,

--- a/grizli/data/photom_correction.yml
+++ b/grizli/data/photom_correction.yml
@@ -167,7 +167,7 @@
 CRDS_CTX: jwst_0995.pmap
 
 # Max context where corrections apply
-CRDS_CTX_MAX: jwst_9999.pmap
+CRDS_CTX_MAX: jwst_1125.pmap
 
 NRCBLONG-F277W-CLEAR: 1.0000
 NRCALONG-F277W-CLEAR: 1.0618

--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -1284,7 +1284,7 @@ def download_jwst_crds_references(instruments=['NIRCAM','NIRISS'], filters=['F09
                                                verbose=verbose)
 
 
-def crds_wfss_reffiles(instrument='NIRCAM', filter='F444W', pupil='GRISMR', module='A', date=None, reftypes=('photom', 'specwcs'), header=None, context=DEFAULT_CRDS_CONTEXT, verbose=False):
+def crds_wfss_reffiles(instrument='NIRCAM', filter='F444W', pupil='GRISMR', module='A', date=None, reftypes=('photom', 'specwcs'), header=None, exp_type='NRC_WFSS', detector=None, context=DEFAULT_CRDS_CONTEXT, verbose=False):
     """
     Get WFSS reffiles from CRDS
     """
@@ -1307,20 +1307,27 @@ def crds_wfss_reffiles(instrument='NIRCAM', filter='F444W', pupil='GRISMR', modu
             
     cpars = {}
     
-    if instrument in ('NIRISS', 'NIRCAM'):
+    if instrument in ('NIRISS', 'NIRCAM', 'MIRI'):
         observatory = 'jwst'
-        cpars['meta.instrument.pupil'] = pupil
+        if instrument not in ['MIRI']:
+            cpars['meta.instrument.pupil'] = pupil
     else:
         observatory = 'hst'
         
     if instrument == 'NIRISS':
         cpars['meta.instrument.detector'] = 'NIS'
-        cpars['meta.exposure.type'] = 'NIS_WFSS'
+        cpars['meta.exposure.type'] = exp_type
     elif instrument == 'NIRCAM':
         cpars['meta.instrument.detector'] = f'NRC{module}LONG'
         cpars['meta.instrument.module'] = module
-        cpars['meta.exposure.type'] = 'NRC_WFSS'
-
+        cpars['meta.exposure.type'] = exp_type
+    elif instrument == 'MIRI':
+        cpars['meta.instrument.detector'] = 'MIR'
+        cpars['meta.exposure.type'] = exp_type
+        
+    if detector is not None:
+        cpars['meta.instrument.detector'] = detector
+    
     if date is None:
         date = astropy.time.Time.now().iso
         

--- a/grizli/jwst_utils.py
+++ b/grizli/jwst_utils.py
@@ -2415,7 +2415,7 @@ def calc_jwst_filter_info():
     return bp
 
 
-def get_crds_zeropoint(instrument='NIRCAM', detector='NRCALONG', filter='F444W', pupil='CLEAR', date=None, context='jwst_1126.pmap', verbose=False, **kwargs):
+def get_crds_zeropoint(instrument='NIRCAM', detector='NRCALONG', filter='F444W', pupil='CLEAR', date=None, context='jwst_0989.pmap', verbose=False, **kwargs):
     """
     Get ``photmjsr`` photometric zeropoint for a partiular JWST instrument imaging
     mode

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -5600,7 +5600,7 @@ def jwst_crds_photom_scale(hdul, context='jwst_1130.pmap', update=True, verbose=
         if k in hdul[0].header:
             mode[k.lower()] = hdul[0].header[k]
     
-    ref_ctx, ref_file, ref_photmjsr = get_crds_zeropoint(**mode)
+    ref_ctx, r_photom, ref_photmjsr = get_crds_zeropoint(**mode)
     if ref_photmjsr is None:
         return 1.0
     
@@ -5620,10 +5620,11 @@ def jwst_crds_photom_scale(hdul, context='jwst_1130.pmap', update=True, verbose=
                     hdul[e].header[k] *= scale
             
             if 'ZP' in hdul[e].header:
-                hdul[e].header -= 2.5*np.log10(scale)
+                hdul[e].header['ZP'] -= 2.5*np.log10(scale)
             
             hdul[e].header['CRDS_CTX'] = context
-    
+            hdul[e].header['R_PHOTOM'] = os.path.basename(r_photom)
+            
     log_comment(LOGFILE, msg, verbose=verbose)
     
     return scale
@@ -5931,6 +5932,11 @@ def drizzle_from_visit(visit, output=None, pixfrac=1., kernel='point',
                                                         context=context,
                                                         verbose=verbose)
             
+            # These might have changed
+            for k in ['PHOTFLAM', 'PHOTFNU', 'PHOTMJSR', 'ZP', 'R_PHOTOM', 'CRDS_CTX']:
+                if k in flt[0].header:
+                    keys[k] = flt[0].header[k]
+
             # Additional scaling
             _key, _scale_photom = get_photom_scale(flt[0].header, 
                                                    verbose=verbose)


### PR DESCRIPTION
- Define a function `jwst_utils.get_crds_zeropoint` to return the ``PHOTMJSR`` scale factor for a given instrument mode and CRDS_CONTEXT
- Use these in `utils.drizzle_from_visit` force a particular context and make sure all exposures of a mosaic use the same values, even if they had different values in the headers.

```python
from grizli import jwst_utils
for context in ['jwst_0989.pmap', 'jwst_1126.pmap']:
    jwst_utils.get_crds_zeropoint(verbose=True, instrument='NIRCAM',
                                  filter='F200W', pupil='CLEAR',
                                  detector='NRCB1',
                                  context=context)

crds_wfss_reffiles: NIRCAM F200W CLEAR B (jwst_0989.pmap)
crds_wfss_reffiles: jwst_nircam_photom_0118.fits
crds_wfss_reffiles: photmjsr = 2.0223

crds_wfss_reffiles: NIRCAM F200W CLEAR B (jwst_1126.pmap)
crds_wfss_reffiles: jwst_nircam_photom_0149.fits
crds_wfss_reffiles: photmjsr = 2.0560