### PR TITLE
No CRDS write

### DIFF
--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -6196,18 +6196,6 @@ def get_jwst_wfssbkg_file(file, valid_flat=[0.6, 1.3], make_figure=False):
     from jwst.wfss_contam import WfssContamStep
     from jwst.flatfield import FlatFieldStep
 
-    
-    with pyfits.open(file) as im:
-        if im[0].header['INSTRUME'] == 'NIRISS':
-            # Test local file
-            local_bkg_file = "nis-{0}-{1}_skyflat.fits"
-            local_bkg_file = local_bkg_file.format(im[0].header['PUPIL'],im[0].header['FILTER'])
-            local_bkg_file = local_bkg_file.lower()
-            local_bkg_file = os.path.join(GRIZLI_PATH, 'CONF',local_bkg_file)
-            
-            if os.path.exists(local_bkg_file):
-                return local_bkg_file
-                    
     bkg_file = WfssContamStep().get_reference_file(file, 'wfssbkg')
 
     # Not a FITS file?  e.g., N/A for imaging exposures
@@ -6221,6 +6209,19 @@ def get_jwst_wfssbkg_file(file, valid_flat=[0.6, 1.3], make_figure=False):
         _im.close()
         return bkg_file
 
+    with pyfits.getval(file,'INSTRUME',0) as h:
+        if h['INSTRUME'] == 'NIRISS'
+            
+            # Test local file
+            local_bkg_file = "nis-{0}-{1}_skyflat.fits"
+            local_bkg_file = local_bkg_file.format(im[0].header['PUPIL'],im[0].header['FILTER'])
+            local_bkg_file = local_bkg_file.lower()
+            local_bkg_file = os.path.join(GRIZLI_PATH, 'CONF',local_bkg_file)
+            
+            # If local file exists and is up-to-date, use it
+            if os.path.exists(local_bkg_file) and pyfits.getval(local_bkg_file,'DATE',0) == h['DATE']:
+                return local_bkg_file
+                    
     flat_file = FlatFieldStep().get_reference_file(file, 'flat')
     
     # If we have write access to file open it

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -6209,18 +6209,18 @@ def get_jwst_wfssbkg_file(file, valid_flat=[0.6, 1.3], make_figure=False):
         _im.close()
         return bkg_file
 
-    with pyfits.getheader(file,0) as h:
-        if h['INSTRUME'] == 'NIRISS':
-            
-            # Test local file
-            local_bkg_file = "nis-{0}-{1}_skyflat.fits"
-            local_bkg_file = local_bkg_file.format(im[0].header['PUPIL'],im[0].header['FILTER'])
-            local_bkg_file = local_bkg_file.lower()
-            local_bkg_file = os.path.join(GRIZLI_PATH, 'CONF',local_bkg_file)
-            
-            # If local file exists and is up-to-date, use it
-            if os.path.exists(local_bkg_file) and pyfits.getval(local_bkg_file,'DATE',0) == h['DATE']:
-                return local_bkg_file
+    h = pyfits.getheader(file,0)
+    if h['INSTRUME'] == 'NIRISS':
+        
+        # Test local file
+        local_bkg_file = "nis-{0}-{1}_skyflat.fits"
+        local_bkg_file = local_bkg_file.format(h['PUPIL'],h['FILTER'])
+        local_bkg_file = local_bkg_file.lower()
+        local_bkg_file = os.path.join(GRIZLI_PATH, 'CONF',local_bkg_file)
+        
+        # If local file exists and is up-to-date, use it
+        if os.path.exists(local_bkg_file) and pyfits.getval(local_bkg_file,'DATE',0) == h['DATE']:
+            return local_bkg_file
                     
     flat_file = FlatFieldStep().get_reference_file(file, 'flat')
     

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -6210,7 +6210,7 @@ def get_jwst_wfssbkg_file(file, valid_flat=[0.6, 1.3], make_figure=False):
         return bkg_file
 
     with pyfits.getheader(file,0) as h:
-        if h['INSTRUME'] == 'NIRISS'
+        if h['INSTRUME'] == 'NIRISS':
             
             # Test local file
             local_bkg_file = "nis-{0}-{1}_skyflat.fits"

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -6224,9 +6224,8 @@ def get_jwst_wfssbkg_file(file, valid_flat=[0.6, 1.3], make_figure=False):
                     
     flat_file = FlatFieldStep().get_reference_file(file, 'flat')
     
-    # If we have write access to file open it
-    # Otherwise copy to local file
-    if not os.access(bkg_file,os.W_OK):    
+    # If we don't have write access copy to local file
+    if (not os.access(bkg_file,os.W_OK)) or (('CRDS_READONLY_CACHE' in os.environ) and (os.environ['CRDS_READONLY_CACHE'] == '1')):
         shutil.copy(bkg_file,local_bkg_file)
         bkg_file = local_bkg_file
     wf = pyfits.open(bkg_file, mode='update')

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -6209,7 +6209,7 @@ def get_jwst_wfssbkg_file(file, valid_flat=[0.6, 1.3], make_figure=False):
         _im.close()
         return bkg_file
 
-    with pyfits.getval(file,'INSTRUME',0) as h:
+    with pyfits.getheader(file,0) as h:
         if h['INSTRUME'] == 'NIRISS'
             
             # Test local file

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -6200,14 +6200,13 @@ def get_jwst_wfssbkg_file(file, valid_flat=[0.6, 1.3], make_figure=False):
     with pyfits.open(file) as im:
         if im[0].header['INSTRUME'] == 'NIRISS':
             # Test local file
-            bkg_file = "nis-{0}-{1}_skyflat.fits"
-            bkg_file = os.path.join(GRIZLI_PATH, 'CONF',
-                                    bkg_file.format(im[0].header['PUPIL'],
-                                                    im[0].header['FILTER']))
-            bkg_file = bkg_file.lower()
+            local_bkg_file = "nis-{0}-{1}_skyflat.fits"
+            local_bkg_file = local_bkg_file.format(im[0].header['PUPIL'],im[0].header['FILTER'])
+            local_bkg_file = local_bkg_file.lower()
+            local_bkg_file = os.path.join(GRIZLI_PATH, 'CONF',local_bkg_file)
             
-            if os.path.exists(bkg_file):
-                return bkg_file
+            if os.path.exists(local_bkg_file):
+                return local_bkg_file
                     
     bkg_file = WfssContamStep().get_reference_file(file, 'wfssbkg')
 

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -6223,6 +6223,11 @@ def get_jwst_wfssbkg_file(file, valid_flat=[0.6, 1.3], make_figure=False):
 
     flat_file = FlatFieldStep().get_reference_file(file, 'flat')
     
+    # If we have write access to file open it
+    # Otherwise copy to local file
+    if not os.access(bkg_file,os.W_OK):    
+        shutil.copy(bkg_file,local_bkg_file)
+        bkg_file = local_bkg_file
     wf = pyfits.open(bkg_file, mode='update')
     key = f"{wf[0].header['FILTER']} {wf[0].header['PUPIL']}"
         


### PR DESCRIPTION
As discussed in #182, grizli attempts to write to a CRDS file, which can cause issues on systems with shared CRDS files that are write protected. The proposed solution was to copy over the file to the local CONF. 

However this does not work due to a big where the entire file path is `.lower()`ed, rather than just the filename (and so only works on case-insensitive filesystems). I fix the issue by only `.lower()`ing the filename, not the entire path (a470bff8b94a2ce499e64dce02e173266d04b0ec). 

To solve the original issue I perform a check to see if the CRDS file is writeable. If not, the CRDS file if copied to the local CONF directory and the changes are applied there (perhaps this should be the default behaviour). Any subsequent processing can then use the writeable version that is created (6d45ab6629bcaac6115403c8b2b0f07d7ac84f9d).

Finally, in the case where the original CRDS file is updated, we must check if the local CONF version is up to date. If out of date, we redo the copying step (97ff0fcd44d9caeede896768e002a0f5c5c111b6 and f49f6eed1c56e103315e7b0f1df4ef982190f416).

These fixes were developed after working through this with @lboogaard with input from @rameyer and @jdavies-st.