### PR TITLE
Skip bad header keywords when making filter combos

### DIFF
--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -4572,7 +4572,8 @@ def make_filter_combinations(root, weight_fnu=2, filter_combinations=FILTER_COMB
             head[band] = im_i[0].header.copy()
         else:
             for k in im_i[0].header:
-                if k == '' or k == 'HISTORY': continue
+                if k in ['', 'HISTORY']:
+                    continue
                 head[band][k] = im_i[0].header[k]
                 
             for k in ref_h_i:

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -4572,6 +4572,7 @@ def make_filter_combinations(root, weight_fnu=2, filter_combinations=FILTER_COMB
             head[band] = im_i[0].header.copy()
         else:
             for k in im_i[0].header:
+                if k == '' or k == 'HISTORY': continue
                 head[band][k] = im_i[0].header[k]
                 
             for k in ref_h_i:


### PR DESCRIPTION
This is a fix for #117 which was briefly mentioned in #182. 
The bug only arises when multiple bands are combined to create detection images.
