### PR TITLE
Remove requirement to install AWS dependency

### DIFF
--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -2124,8 +2124,6 @@ def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-
     import matplotlib.pyplot as plt
     import astropy.io.fits as pyfits
     
-    import boto3
-    
     from grizli import utils
     from mastquery import overlaps
     
@@ -2170,6 +2168,7 @@ def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-
     
     SQL += ' ORDER BY e.filter'
     if res is None:
+        import boto3
         res = db.SQL(SQL)
     
     if len(res) == 0:

--- a/grizli/pipeline/default_params.py
+++ b/grizli/pipeline/default_params.py
@@ -81,7 +81,7 @@ def test_aws_availability():
     """
     Test if aws s3 is available
     """
-    s3_status = os.system('aws s3 ls s3://stpubdata --request-payer requester > /tmp/aws.x')
+    s3_status = os.system('aws s3 ls s3://stpubdata --request-payer requester > /tmp/aws.x 2>&1')
     if s3_status == 0:
         s3_sync = 'cp'  # As of late October 2018, 's3 sync' not working with 'stpubdata'
     else:


### PR DESCRIPTION
When running NIRISS JWST data, `grizli` usually requires that `awscl` and `boto3` be installed. E.g. one must install using `pip install grizli[jwst,aws]`. I believe I have removed these requirements if AWS is **not** being used. In addition, I have suppressed messages that notify the use that `awscli` is not installed when used to test if the `awscli` is installed or not. 