### PR TITLE
Return Time object by default with `utils.nowtime`

### DIFF
--- a/grizli/aws/db.py
+++ b/grizli/aws/db.py
@@ -1049,7 +1049,7 @@ def wait_on_db_update(root, t0=60, dt=30, n_iter=60, engine=None):
         if (n == n_i) & (checksum == checksum_i) & (n6 == n6_i):
             break
 
-        now = utils.nowtime()
+        now = utils.nowtime().iso
         print('{0}, {1}: n={2:<5d} n5={5:<5d} n6={3:<5d} checksum={4}'.format(root, now, n, n6, checksum, n5))
         n_i, n6_i, checksum_i = n, n6, checksum
         if i == 0:
@@ -1820,7 +1820,7 @@ def SQL(query_text, engine=None, pd_kwargs={}, **kwargs):
     
     tab = utils.GTable.from_pandas(res)
     tab.meta['query'] = (query_text, 'SQL query text')
-    tab.meta['qtime'] = (utils.nowtime(), 'Query timestamp')
+    tab.meta['qtime'] = (utils.nowtime().iso, 'Query timestamp')
     
     set_column_formats(tab, **kwargs)
 
@@ -2657,7 +2657,7 @@ def make_html_table(engine=None, columns=['root', 'status', 'id', 'p_ra', 'p_dec
         ax.legend(loc='upper right')
 
         fig.tight_layout(pad=0.1)
-        fig.text(1-0.02, 0.02, utils.nowtime(), ha='right', va='bottom', 
+        fig.text(1-0.02, 0.02, utils.nowtime().iso, ha='right', va='bottom',
                  transform=fig.transFigure, fontsize=5)
 
         fig.savefig('{0}_zhist.png'.format(table_root))

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -503,23 +503,26 @@ def go(root='j010311+131615',
             skyfile = get_miri_flat_by_date(files[0])
             
             if skyfile is None:
+
+                skyfile = os.path.join(PATHS['prep'], f'{root}_skyflat.fits')
                 
                 msg = f"{root} : global_miri_skyflat N={len(files)}"
                 utils.log_comment(utils.LOGFILE, msg, show_date=False,
                                   verbose=True)
             
                 os.chdir(PATHS['prep'])
-                for file in files:
-                    prep.fresh_flt_file(file, use_skyflats=False)
-            
-                prep.make_visit_average_flat({'product':root,
-                                              'files':files},
-                                              dilate=1,
-                                              threshold=5,
-                                              clip_max=np.minimum(len(files)//2,4),
-                                              apply=False)
                 
-                skyfile = os.path.join(PATHS['prep'], f'{root}_skyflat.fits')
+                # Don't redo if file found
+                if not os.path.exists(skyfile):
+                    for file in files:
+                        prep.fresh_flt_file(file, use_skyflats=False)
+            
+                    prep.make_visit_average_flat({'product':root,
+                                                  'files':files},
+                                                  dilate=1,
+                                                  threshold=5,
+                                                  clip_max=np.minimum(len(files)//2,4),
+                                                  apply=False)
             
             visit_prep_args['miri_skyflat'] = False
             visit_prep_args['use_skyflats'] = False

--- a/grizli/tests/test_utils.py
+++ b/grizli/tests/test_utils.py
@@ -44,6 +44,20 @@ class UtilsTester(unittest.TestCase):
         assert(iso == '2019-09-16 11:23:27.000')
 
 
+    def test_nowtime(self):
+        """
+        nowtime
+        """
+        iso = utils.nowtime(iso=True)
+        assert(iso.startswith('202'))
+
+        iso = utils.nowtime().iso
+        assert(iso.startswith('202'))
+
+        mjd = utils.nowtime().mjd
+        assert(mjd > 60000)
+
+
     def test_multiprocessing_ndfilter(self):
         """
         Test the multiprocessing filter

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -9182,7 +9182,7 @@ def ctime_to_iso(mtime, format='%a %b %d %H:%M:%S %Y', strip_decimal=True, verbo
     return iso
 
 
-def nowtime(iso=True):
+def nowtime(iso=False):
     """
     Wrapper for `astropy.time.now`
 
@@ -9253,7 +9253,7 @@ def log_comment(LOGFILE, comment, verbose=False, show_date=False, mode='a'):
     import time
 
     if show_date:
-        msg = '# ({0})\n'.format(nowtime())
+        msg = '# ({0})\n'.format(nowtime().iso)
     else:
         msg = ''
 
@@ -9293,7 +9293,7 @@ def log_exception(LOGFILE, traceback, verbose=True, mode='a'):
 
     trace = traceback.format_exc(limit=2)
     log = '\n########################################## \n'
-    log += '# ! Exception ({0})\n'.format(nowtime())
+    log += '# ! Exception ({0})\n'.format(nowtime().iso)
     log += '#\n# !'+'\n# !'.join(trace.split('\n'))
     log += '\n######################################### \n\n'
     if verbose | (LOGFILE is None):


### PR DESCRIPTION
Before `grizli.utils.nowtime` returned the "ISO" time format by default.  With this update, return the `astropy.time.Time` object by default, which has an `iso` attribute (as well as `mjd`, etc.).

