### PR TITLE
Update filter lists to enable NIRISS F090W WFSS processing

### DIFF
--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -1341,6 +1341,9 @@ def load_grism_config(conf_file, warnings=True):
      """
             msg = f' ! Scale NIRISS sensitivity by {hack_niriss:.3f} prelim flux correction'
             utils.log_comment(utils.LOGFILE, msg, verbose=warnings)
+        elif 'F090W' in conf_file:
+            # hack_niriss = 0.8
+            hack_niriss = 1.0
         else:
             hack_niriss = 1.0
             
@@ -1356,6 +1359,8 @@ def load_grism_config(conf_file, warnings=True):
             # for b in conf.beams:
             #     #conf.conf[f'DYDX_{b}_0'][0] += 0.25
             #     conf.conf[f'DLDP_{b}_0'] -= conf.conf[f'DLDP_{b}_1']*0.5
+        elif ('F090W' in conf_file) | ('.2212' in conf_file):
+            pass
         elif isinstance(conf, TransformGrismconf):
             # Don't shift new format files
             pass

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -21,6 +21,7 @@ from .. import catalog as grizli_catalog
 from .default_params import UV_N_FILTERS, UV_M_FILTERS, UV_W_FILTERS
 from .default_params import OPT_N_FILTERS, OPT_M_FILTERS, OPT_W_FILTERS
 from .default_params import IR_N_FILTERS, IR_M_FILTERS, IR_W_FILTERS
+from .default_params import NIRISS_FILTERS, NIRCAM_SW_FILTERS, NIRCAM_LW_FILTERS
 from .default_params import ALL_IMAGING_FILTERS, VALID_FILTERS
 from .default_params import UV_GRISMS, OPT_GRISMS, IR_GRISMS, GRIS_REF_FILTERS
 
@@ -4667,9 +4668,9 @@ def drizzle_overlaps(field_root, filters=['F098M', 'F105W', 'F110W', 'F115W', 'F
                               run_driz_cr=filter_driz_cr, **kwargs)
 
 
-FILTER_COMBINATIONS = {'ir': IR_M_FILTERS+IR_W_FILTERS,
-                       'opt': OPT_M_FILTERS+OPT_W_FILTERS}
-
+FILTER_COMBINATIONS = {'ir': (IR_M_FILTERS + IR_W_FILTERS + 
+                              NIRISS_FILTERS + NIRCAM_LW_FILTERS),
+                       'opt': OPT_M_FILTERS + OPT_W_FILTERS}
 
 def make_filter_combinations(root, weight_fnu=2, filter_combinations=FILTER_COMBINATIONS, force_photfnu=1.e-8, min_count=1, block_filters=[]):
     """

--- a/grizli/pipeline/default_params.py
+++ b/grizli/pipeline/default_params.py
@@ -15,29 +15,37 @@ IR_M_FILTERS = ['F098M', 'F127M', 'F139M', 'F153M']
 IR_W_FILTERS = ['F105W', 'F110W', 'F125W', 'F140W', 'F160W']
 
 NIRISS_FILTERS = ['F090W', 'F115W', 'F150W', 'F200W', 
-                    'F277W', 'F356W', 'F444W',
-                    'F140M', 'F158M', 'F380M', 'F430M', 'F480M']
+                  'F277W', 'F356W', 'F444W',
+                  'F140M', 'F158M', 'F380M', 'F430M', 'F480M']
+                   
 NIRCAM_LW_FILTERS = ['F322W2', 'F277W', 'F356W', 'F444W', 
-                    'F250M', 'F300M', 'F335M', 'F360M', 'F410M', 'F430M', 'F460M', 'F480M',
+                    'F250M', 'F300M', 'F335M', 'F360M', 'F410M',
+                    'F430M', 'F460M', 'F480M',
                     'F323N', 'F405N', 'F466N', 'F470N']
+
 NIRCAM_SW_FILTERS = ['F150W2', 'F070W', 'F090W', 'F115W', 'F150W', 'F200W', 
-                        'F140M', 'F162M', 'F182M', 'F210M', 
-                        'F164N', 'F187N', 'F212N']
+                     'F140M', 'F162M', 'F182M', 'F210M', 
+                     'F164N', 'F187N', 'F212N']
+
 MIRI_FILTERS = ['F560W', 'F770W', 'F1000W', 'F1130W', 'F1280W', 
                 'F1500W', 'F1800W', 'F2100W', 'F2550W']
+
 JW_FILTERS = np.unique(NIRISS_FILTERS + NIRCAM_LW_FILTERS + NIRCAM_SW_FILTERS + MIRI_FILTERS).tolist()
 
-OPT_N_FILTERS = ['F469N', 'F487N', 'F502N']
+OPT_N_FILTERS =  ['F469N', 'F487N', 'F502N']
 OPT_N_FILTERS += ['FQ436N', 'FQ437N', 'FQ492N', 'FQ508N', 'FQ575N']
 OPT_N_FILTERS += ['F631N', 'F645N', 'F656N', 'F657N', 'F658N', 
-                    'F660N', 'F665N', 'F673N', 'F680N']
+                  'F660N', 'F665N', 'F673N', 'F680N']
 OPT_N_FILTERS += ['FQ619N', 'FQ634N', 'FQ672N', 'FQ674N', 'FQ727N', 'FQ750N', 
-                    'FQ889N', 'FQ906N', 'FQ924N', 'FQ937N', 'F892N', 'F953N']
+                  'FQ889N', 'FQ906N', 'FQ924N', 'FQ937N', 'F892N', 'F953N']
 
-OPT_M_FILTERS = ['F410M', 'F467M', 'F547M', 'F550M', 'F621M', 'F689M', 'F763M', 'F845M']
-OPT_W_FILTERS = ['F200LP', 'F350LP', 'F435W', 'F438W', 'F439W', 'F450W', 'F475W', 'F475X', 
-                    'F555W', 'F569W', 'F600LP', 'F606W', 'F622W', 'F625W', 'F675W', 'F702W', 
-                    'F775W', 'F791W', 'F814W', 'F850LP']
+OPT_M_FILTERS = ['F410M', 'F467M', 'F547M', 'F550M', 'F621M',
+                 'F689M', 'F763M', 'F845M']
+OPT_W_FILTERS = ['F200LP', 'F350LP', 'F435W', 'F438W', 'F439W',
+                 'F450W', 'F475W', 'F475X', 
+                 'F555W', 'F569W', 'F600LP', 'F606W', 'F622W',
+                 'F625W', 'F675W', 'F702W', 
+                 'F775W', 'F791W', 'F814W', 'F850LP']
 
 UV_N_FILTERS = ['F280N', 'F343N', 'F373N', 'F395N']
 UV_N_FILTERS += ['FQ232N', 'FQ243N', 'FQ378N']
@@ -66,9 +74,11 @@ GRIS_REF_FILTERS = {'G141': ['F140W', 'F160W', 'F125W', 'F105W', 'F110W',
                              'F130N', 'F128N', 'F126N', 'F164N', 'F167N'],
                     'G800L': ['F814W', 'F850LP', 'F606W', 'F435W', 'F775W',
                               'F555W', 'opt'], 
-                    'GR150C': ['F115W', 'F150W', 'F200W', 
+                    'GR150C': ['F115W', 'F150W', 'F200W',
+                               'F090W', 'CLEAR-F090W',
                                'CLEAR-F115W', 'CLEAR-F150W', 'CLEAR-F200W'], 
                     'GR150R': ['F115W', 'F150W', 'F200W',
+                               'F090W', 'CLEAR-F090W',
                                'CLEAR-F115W', 'CLEAR-F150W', 'CLEAR-F200W'],
                     'GRISMR': ['F277W-CLEAR','F356W-CLEAR','F410M-CLEAR',
                                'F444W-CLEAR','F277W','F356W','F410M','F444W'],

--- a/grizli/pipeline/default_params.py
+++ b/grizli/pipeline/default_params.py
@@ -76,10 +76,16 @@ GRIS_REF_FILTERS = {'G141': ['F140W', 'F160W', 'F125W', 'F105W', 'F110W',
                               'F555W', 'opt'], 
                     'GR150C': ['F115W', 'F150W', 'F200W',
                                'F090W', 'CLEAR-F090W',
-                               'CLEAR-F115W', 'CLEAR-F150W', 'CLEAR-F200W'], 
+                               'CLEAR-F115W', 'CLEAR-F150W', 'CLEAR-F200W',
+                               'F090WN-CLEAR', 'F115WN-CLEAR', 'F150WN-CLEAR',
+                               'F200WN-CLEAR'
+                              ],
                     'GR150R': ['F115W', 'F150W', 'F200W',
                                'F090W', 'CLEAR-F090W',
-                               'CLEAR-F115W', 'CLEAR-F150W', 'CLEAR-F200W'],
+                               'CLEAR-F115W', 'CLEAR-F150W', 'CLEAR-F200W'
+                               'F090WN-CLEAR', 'F115WN-CLEAR', 'F150WN-CLEAR',
+                               'F200WN-CLEAR'
+                               ],
                     'GRISMR': ['F277W-CLEAR','F356W-CLEAR','F410M-CLEAR',
                                'F444W-CLEAR','F277W','F356W','F410M','F444W'],
                     'GRISMC': ['F277W-CLEAR','F356W-CLEAR','F410M-CLEAR',


### PR DESCRIPTION
Add ``F090W`` to filter lists so that it is included as an available filter for NIRISS WFSS processing.