### PR TITLE
Fixed incorrect PASSAGE id

### DIFF
--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -1851,7 +1851,7 @@ def parse_visits(files=[], field_root='', RAW_PATH='../RAW', use_visit=True, com
     # Remove visit number from NIRISS parallel visits
     for v in visits:
         IS_NIS_PARALLEL = v['product'].startswith('indef-03383')
-        IS_NIS_PARALLEL |= v['product'].startswith('indef-01471')
+        IS_NIS_PARALLEL |= v['product'].startswith('indef-01571')
 
         ks = v['product'].split('-')
         


### PR DESCRIPTION
Remove visit number fails with PASSAGE as the program ID is given incorrectly. 