### PR TITLE
Compute time-dependent photometric correction for MIRI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -36,14 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Build sdist
         run: |
           pip install build
           python -m build --sdist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 
@@ -56,7 +56,7 @@ jobs:
         github.event.ref_type == 'tag' &&
         github.ref == 'refs/heads/${{ github.event.repository.default_branch }}'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist

--- a/.github/workflows/python-package-with-jwst.yml
+++ b/.github/workflows/python-package-with-jwst.yml
@@ -21,9 +21,9 @@ jobs:
         python-version: ['3.9', '3.10']
         os: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: [3.8, 3.9, '3.10']
         os: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Build check
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package
@@ -54,11 +54,11 @@ jobs:
         python-version: [3.8, 3.9, '3.10']
         os: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,7 +35,7 @@ jobs:
         python-version: ['3.10']
         os: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/grizli/tests/test_jwst.py
+++ b/grizli/tests/test_jwst.py
@@ -184,6 +184,11 @@ class TestJWSTUtils:
     
     def test_miri_photom(self):
         
+        try:
+            import jwst
+        except ImportError:
+            return None
+        
         photmjsr, corr = jwst_utils.get_miri_photmjsr(
                                         file=None,
                                         filter='F770W',

--- a/grizli/tests/test_jwst.py
+++ b/grizli/tests/test_jwst.py
@@ -180,6 +180,33 @@ class TestJWSTUtils:
         info = jwst_utils.get_jwst_filter_info(header)
         assert(info['name'] == 'F560W')
         assert(np.allclose(info['pivot'], 5.632612))
+    
+    
+    def test_miri_photom(self):
+        
+        photmjsr, corr = jwst_utils.get_miri_photmjsr(
+                                        file=None,
+                                        filter='F770W',
+                                        subarray='FULL',
+                                        mjd=60153.23,
+                                        photom_file='jwst_miri_photom_0201.fits',
+                                        verbose=True,
+                                    )
+        
+        assert np.allclose([photmjsr], 0.25890106)
+        assert np.allclose([corr], 0.)
+        
+        # Missing filter
+        photmjsr, corr = jwst_utils.get_miri_photmjsr(
+                                        file=None,
+                                        filter='xF770W',
+                                        subarray='FULL',
+                                        mjd=60153.23,
+                                        photom_file='jwst_miri_photom_0201.fits',
+                                        verbose=True,
+                                    )
+        
+        assert np.isnan(photmjsr)
 
 
 class TestJWSTFittingTools:


### PR DESCRIPTION
Compute time-dependent correction factor to MIRI photometric calibration.

See, e.g. https://github.com/spacetelescope/jwst/issues/8048, https://github.com/spacetelescope/jwst/pull/8096, and https://github.com/spacetelescope/jwst/blob/master/jwst/photom/miri_imager.py.

Note that this update just implements calculating the correction factor, but it is not yet used, e.g., when creating mosaics.
