### PR TITLE
Mask outliers in BKG extensions in `drizzle_from_visit`

### DIFF
--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -6281,11 +6281,14 @@ def drizzle_from_visit(visit, output=None, pixfrac=1., kernel='point',
                     # Clipping threshold for BKG extensions, global at top
                     # BKG_CLIP = [scale, percentile_lo, percentile_hi]
                     if has_bkg & (BKG_CLIP is not None):
-                        _bkg_clip = np.nanpercentile(
+                        bkg_lo, bkg_hi = np.nanpercentile(
                             flt['BKG'].data[dq == 0], BKG_CLIP[1:3]
                         )
-                        _bad_bkg = flt['BKG'].data < BKG_CLIP[0]*_bkg_clip[0]
-                        _bad_bkg |= flt['BKG'].data > BKG_CLIP[0]*_bkg_clip[1]
+                        # make sure lower (upper) limit is negative (positive)
+                        clip_lo = -np.abs(bkg_lo)
+                        clip_hi = np.abs(bkg_hi)
+                        _bad_bkg = flt['BKG'].data < BKG_CLIP[0]*bkg_lo
+                        _bad_bkg |= flt['BKG'].data > BKG_CLIP[0]*bkg_hi
                         
                         msg = f'Bad bkg pixels: N= {_bad_bkg.sum()} '
                         msg += f' ( {_bad_bkg.sum()/_bad_bkg.size*100:.1} %)'

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -6281,20 +6281,24 @@ def drizzle_from_visit(visit, output=None, pixfrac=1., kernel='point',
                     # Clipping threshold for BKG extensions, global at top
                     # BKG_CLIP = [scale, percentile_lo, percentile_hi]
                     if has_bkg & (BKG_CLIP is not None):
+                        # percentiles
                         bkg_lo, bkg_hi = np.nanpercentile(
                             flt['BKG'].data[dq == 0], BKG_CLIP[1:3]
                         )
+
                         # make sure lower (upper) limit is negative (positive)
                         clip_lo = -np.abs(bkg_lo)
                         clip_hi = np.abs(bkg_hi)
+
                         _bad_bkg = flt['BKG'].data < BKG_CLIP[0]*bkg_lo
                         _bad_bkg |= flt['BKG'].data > BKG_CLIP[0]*bkg_hi
-                        
+
+                        # OR into dq mask
                         msg = f'Bad bkg pixels: N= {_bad_bkg.sum()} '
                         msg += f' ( {_bad_bkg.sum()/_bad_bkg.size*100:.1} %)'
                         log_comment(LOGFILE, msg, verbose=verbose)
                         dq |= _bad_bkg*1024
-                        
+
                 else:
                     dq = (mod_dq_bits(flt[('DQ', ext)].data, okbits=bits)
                           | bpdata)


### PR DESCRIPTION
Add a global variable `BKG_CLIP` used in  `grizli.utils.drizzle_from_visit` to mask outlier pixels in the `BKG` extension of grizli-processed JWST exposures.  There are a few examples where there are excessively negative pixels in the BKG maps that then show up as stripes of bad pixels in the combined mosaic.  

The three elements of the `BKG_CLIP` array are interpreted as 

```python
BKG_CLIP = [scale, percentile_lo, percentile_hi]

# Clip percentiles
bkg_lo, bkg_hi = np.nanpercentile(flt['BKG'].data[valid], BKG_CLIP[1:3])

# make sure lower (upper) limit is negative (positive)
clip_lo = -np.abs(bkg_lo)
clip_hi = np.abs(bkg_hi)

_badpix = flt['BKG'].data < BKG_CLIP[0]*bkg_lo
_badpix |= flt['BKG'].data > BKG_CLIP[0]*bkg_hi
```

where the `_badpix` mask is added to the DQ mask for that exposure.

To turn off the masking, set `grizli.utils.BKG_CLIP = None` (it's not currently implemented as a keyword argument on `grizli.utils.drizzle_from_visit` ).