### PR TITLE
NIRCam hot pixel flagging

### DIFF
--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -2309,7 +2309,9 @@ def cutout_mosaic(rootname='gds', product='{rootname}-{f}', ra=53.1615666, dec=-
                                      snowblind_kwargs=snowblind_kwargs,
                                      weight_type=weight_type,
                                      rnoise_percentile=rnoise_percentile,
-                                     calc_wcsmap=calc_wcsmap)
+                                     calc_wcsmap=calc_wcsmap,
+                                     **kwargs,
+                                     )
                              
         outsci, outwht, header, flist, wcs_tab = _
         

--- a/grizli/jwst_utils.py
+++ b/grizli/jwst_utils.py
@@ -233,7 +233,7 @@ def get_jwst_dq_bit(dq_flags=JWST_DQ_FLAGS, verbose=False):
         import jwst.datamodels
     except:
         msg = f"get_jwst_dq_bits: import jwst.datamodels failed"
-        log_comment(LOGFILE, msg, verbose=verbose)
+        utils.log_comment(utils.LOGFILE, msg, verbose=verbose)
         return 1
         
     dq_flag = 1

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -5925,7 +5925,15 @@ def drizzle_from_visit(visit, output=None, pixfrac=1., kernel='point',
     snowblind_kwargs : dict
         Arguments to pass to `~grizli.utils.jwst_snowblind_mask` if `snowblind` hasn't
         already been run on JWST exposures
-    
+
+    jwst_dq_flags : list
+        List of JWST flag names to include in the bad pixel mask.  To ignore, set to
+        ``None``
+
+    nircam_hot_pixel_kwargs : dict
+        Keyword arguments for `grizli.jwst_utils.flag_nircam_hot_pixels`.  Set to
+        ``None`` to disable and use the static bad pixel tables.
+
     Returns
     -------
     outsci : array-like

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -21,6 +21,7 @@ import astropy.units as u
 from sregion import SRegion, patch_from_polygon
 
 from . import GRIZLI_PATH
+from .jwst_utils import JWST_DQ_FLAGS
 
 KMS = u.km/u.s
 FLAMBDA_CGS = u.erg/u.s/u.cm**2/u.angstrom
@@ -5852,7 +5853,10 @@ def drizzle_from_visit(visit, output=None, pixfrac=1., kernel='point',
                        calc_wcsmap=False,
                        niriss_ghost_kwargs={},
                        snowblind_kwargs=None,
-                       get_dbmask=True):
+                       jwst_dq_flags=JWST_DQ_FLAGS,
+                       nircam_hot_pixel_kwargs={},
+                       get_dbmask=True,
+                       **kwargs):
     """
     Make drizzle mosaic from exposures in a visit dictionary
     
@@ -5947,6 +5951,7 @@ def drizzle_from_visit(visit, output=None, pixfrac=1., kernel='point',
     
     from .prep import apply_region_mask_from_db
     from .version import __version__ as grizli__version
+    from .jwst_utils import get_jwst_dq_bit, flag_nircam_hot_pixels
     
     bucket_name = None
     
@@ -6077,6 +6082,20 @@ def drizzle_from_visit(visit, output=None, pixfrac=1., kernel='point',
             
             #bpdata = 0
             _inst = flt[0].header['INSTRUME']
+            
+            # Directly flag hot pixels rather than use mask
+            if (_inst in ['NIRCAM']) & (nircam_hot_pixel_kwargs is not None):
+                _sn, dq_flag, _count = flag_nircam_hot_pixels(
+                    flt,
+                    **nircam_hot_pixel_kwargs
+                )
+                if (_count > 0) & (_count < 8192):
+                    bpdata = (dq_flag > 0)*1024
+                    extra_wfc3ir_badpix = False
+                else:
+                    msg = f' flag_nircam_hot_pixels: {_count} out of range'
+                    log_comment(LOGFILE, msg, verbose=verbose)
+                    
             if (extra_wfc3ir_badpix) & (_inst in ['NIRCAM','NIRISS']):
                 _det = flt[0].header['DETECTOR']
                 bpfiles = [os.path.join(os.path.dirname(__file__),
@@ -6276,7 +6295,11 @@ def drizzle_from_visit(visit, output=None, pixfrac=1., kernel='point',
                 
                 # JWST: just 1,1024,4096 bits
                 if flt[0].header['TELESCOP'] in ['JWST']:
-                    dq = flt[('DQ', ext)].data & (1+1024+4096)
+                    bad_bits = (1 | 1024 | 4096)
+                    if jwst_dq_flags is not None:
+                        bad_bits |= get_jwst_dq_bit(jwst_dq_flags, verbose=verbose)
+                    
+                    dq = flt[('DQ', ext)].data & bad_bits
                     dq |= bpdata.astype(dq.dtype)
 
                     # Clipping threshold for BKG extensions, global at top


### PR DESCRIPTION
Add a function `grizli.jwst_utils.flag_nircam_hot_pixels` to 
1. Flag isolated hot pixels defined to be pixels that exceed a S/N threshold and whose *neighbors* have S/N less than some tolerance.
2. Flag "plusses" around some known hot pixels

This is run in `utils.drizzle_from_visit` (inherited by `aws.visit_processor.cutout_mosaic`).  If such pixels are identified, it then skips adding the static bad pixel tables, where the latter somewhat conservatively flag a cumulative list of bad pixels.

Also added is an option to include an expanded specified list of [JWST bad pixel flags](https://jwst-pipeline.readthedocs.io/en/latest/jwst/references_general/references_general.html#data-quality-flags) in the mask.  These are both turned on by default and are controlled with the following

```python
JWST_DQ_FLAGS = [
    "DO_NOT_USE",
    "OTHER_BAD_PIXEL",
    "UNRELIABLE_SLOPE",
    "UNRELIABLE_BIAS",
    "NO_SAT_CHECK",
    "NO_GAIN_VALUE",
    "HOT",
    "WARM",
    "DEAD",
    "RC",
    "LOW_QE",
]

# Set either option below to None to turn off
grizli.utils.drizzle_from_visit(...,
    jwst_dq_flags=JWST_DQ_FLAGS,
    nircam_hot_pixel_kwargs={},
)
```

### Demo:
```python
import numpy as np
import matplotlib.pyplot as plt
import astropy.io.fits as pyfits

from grizli.jwst_utils import flag_nircam_hot_pixels

signal = np.zeros((48,48), dtype=np.float32)

# hot
signal[16,16] = 10

# plus
for off in [-1,1]:
    signal[32+off, 32] = 10
    signal[32, 32+off] = 7

err = np.ones_like(signal)
np.random.seed(1)
noise = np.random.normal(size=signal.shape)*err

dq = np.zeros(signal.shape, dtype=int)
dq[32,32] = 2048 # HOT

header = pyfits.Header()
header['MDRIZSKY'] = 0.

hdul = pyfits.HDUList([
    pyfits.ImageHDU(data=signal+noise, name='SCI', header=header),
    pyfits.ImageHDU(data=err, name='ERR'),
    pyfits.ImageHDU(data=dq, name='DQ'),
])

sn, dq_flag, count = flag_nircam_hot_pixels(hdul)

fig, axes = plt.subplots(1,2,figsize=(8,4), sharex=True, sharey=True)

axes[0].imshow(signal + noise, vmin=-2, vmax=9, cmap='gray')
axes[0].set_xlabel('Simulated data')
axes[1].imshow(dq_flag, cmap='magma')
axes[1].set_xlabel('Flagged pixels')

for ax in axes:
    ax.set_xticklabels([])
    ax.set_yticklabels([])

fig.tight_layout(pad=1)
```
![nircam_hotpix](https://github.com/gbrammer/grizli/assets/1577270/b261fa19-a674-4399-8ba5-289bd2926898)

