### PR TITLE
 Compliance with NumPy 2.0

### DIFF
--- a/grizli/aws/aws_drizzler.py
+++ b/grizli/aws/aws_drizzler.py
@@ -484,7 +484,7 @@ def segmentation_figure(label, cat, segfile):
     blot_seg = utils.blot_nearest_exact(seg_data, seg_wcs, th_wcs,
                                stepsize=-1, scale_by_pixel_area=False)
 
-    rnd_seg = rnd_ids[np.cast[int](blot_seg)]*1.
+    rnd_seg = rnd_ids[np.asarray(blot_seg,dtype=int)]*1.
     th_ids = np.unique(blot_seg)
 
     sh = th[0].data.shape
@@ -521,7 +521,7 @@ def segmentation_figure(label, cat, segfile):
     plt.close(fig)
 
     # Append to thumbs file
-    seg_hdu = pyfits.ImageHDU(data=np.cast[int](blot_seg), name='SEG')
+    seg_hdu = pyfits.ImageHDU(data=np.asarray(blot_seg,dtype=int), name='SEG')
     if 'SEG' in th:
         th.pop('SEG')
 

--- a/grizli/aws/db.py
+++ b/grizli/aws/db.py
@@ -757,7 +757,7 @@ def add_oned_spectra(root='j214224m4420gr01', bucket='grizli-v2', engine=None):
 
         resp = fresp[sel]
 
-        norm_ix = np.cast[int](np.round(np.interp(wnorm*(1+resp['z_map']), wave, np.arange(len(wave)), left=np.nan, right=np.nan)))
+        norm_ix = np.asarray(np.round(np.interp(wnorm*(1+resp['z_map']), wave, np.arange(len(wave)), left=np.nan, right=np.nan)),dtype=int)
 
         resp.sort_values(sort_column, inplace=True)
 
@@ -781,8 +781,8 @@ def add_oned_spectra(root='j214224m4420gr01', bucket='grizli-v2', engine=None):
 
         # Rest-frame
         dz = np.diff(wave)[10]/wave[10]
-        max_zshift = np.cast[int](np.log(1+resp['z_map'].max())/dz)
-        zshift = np.cast[int]((np.log(1+resp['z_map']) - np.log(1+zref))/dz)
+        max_zshift = np.asarray(np.log(1+resp['z_map'].max())/dz,dtype=int)
+        zshift = np.asarray((np.log(1+resp['z_map']) - np.log(1+zref))/dz,dtype=int)
 
         err_max = 5
 
@@ -1410,7 +1410,7 @@ def multibeam_to_database(beams_file, engine=None, Rspline=15, force=False, **kw
 
                 dtype[c[:-1]+'_p'] = types.ARRAY(types.FLOAT)
 
-                data[c[:-1]+'_p'] = [list(np.cast[float](line.strip()[1:-1].split(','))) for line in df[c]]
+                data[c[:-1]+'_p'] = [list(np.asarray(line.strip()[1:-1].split(','),dtype=float)) for line in df[c]]
 
         data.to_sql('multibeam_tmp', engine, index=False, if_exists='append', method='multi')
 
@@ -2491,7 +2491,7 @@ def query_from_ds9(ds9, radius=5, engine=None, extra_cols=['mag_auto', 'z_map', 
     if engine is None:
         engine = get_db_engine(echo=False)
 
-    ra, dec = np.cast[float](ds9.get('pan fk5').split())
+    ra, dec = np.asarray(ds9.get('pan fk5').split(),dtype=float)
     dd = radius/3600.
     dr = dd/np.cos(dec/180*np.pi)
 
@@ -2731,9 +2731,9 @@ def get_exposure_info():
         print(file)
         _q = Table.read(file, character_as_bytes=False)
 
-        _q['proposal_id'] = np.cast[np.int16](_q['proposal_id'])
-        _q['obsid'] = np.cast[np.int64](_q['obsid'])
-        _q['objID'] = np.cast[np.int64](_q['objID'])
+        _q['proposal_id'] = np.asarray(_q['proposal_id'],dtype=np.int16)
+        _q['obsid'] = np.asarray(_q['obsid'],dtype=np.int64)
+        _q['objID'] = np.asarray(_q['objID'],dtype=np.int64)
         _q.rename_column('ra','target_ra')
         _q.rename_column('dec','target_dec')
         _q.rename_column('footprint', 'sregion')
@@ -2750,7 +2750,7 @@ def get_exposure_info():
         print(i, file)
         _p = Table.read(file, character_as_bytes=False)
 
-        _p['obsid'] = np.cast[np.int64](_p['obsid'])
+        _p['obsid'] = np.asarray(_p['obsid'],dtype=np.int64)
         _p['dataset'] = [d[:-1] for d in _p['observation_id']]
 
         df = _p[cols].to_pandas()

--- a/grizli/aws/define_mosaics.py
+++ b/grizli/aws/define_mosaics.py
@@ -274,7 +274,7 @@ END""")
             # Centered
             rc, dc = 3.4573691, -30.3660376
         
-            xc, yc = np.cast[int](np.round(np.squeeze(xivo_wcs.all_world2pix([rc], [dc], 0))))
+            xc, yc = np.asarray(np.round(np.squeeze(xivo_wcs.all_world2pix([rc], [dc], 0))),dtype=int)
             #print('xxx', xc, yc, NP)
         
             NX = 5*2048
@@ -288,7 +288,7 @@ END""")
             # New pointing fully including GLASS + UNCOVER/NIS
             rc, dc = 3.4793842, -30.3562169
         
-            xc, yc = np.cast[int](np.round(np.squeeze(xivo_wcs.all_world2pix([rc], [dc], 0))))
+            xc, yc = np.asarray(np.round(np.squeeze(xivo_wcs.all_world2pix([rc], [dc], 0))),dtype=int)
             #print('xxx', xc, yc, NP)
         
             NX = 6*2048
@@ -689,7 +689,7 @@ END""")
         # Slices
         llr, lld = w.all_pix2world([0],[0], 0)
         ll = np.squeeze(full_wcs.all_world2pix(llr, lld, 0))
-        llx, lly = np.cast[int](np.floor(ll))
+        llx, lly = np.asarray(np.floor(ll),dtype=int)
     
         wh = utils.get_wcs_slice_header(full_wcs,
                                         slice(llx, llx+NX*2048),
@@ -998,7 +998,7 @@ NAXIS2  =                 4049                                                  
         root = f'abell370-{fi}-grizli-v6.0'
         root = f'abell370-{fi}-grizli-{version}' 
 
-        xi, yi = np.cast[int](np.squeeze(full_wcs.all_world2pix([r0], [d0], 0)))
+        xi, yi = np.asarray(np.squeeze(full_wcs.all_world2pix([r0], [d0], 0)),dtype=int)
     
         wh = utils.get_wcs_slice_header(full_wcs,
                                         slice(xi-int(nnx*2048), xi+int(nnx*2048)),
@@ -1039,7 +1039,7 @@ NAXIS2  =                 4049                                                  
         root = f'macs0416-{fi}-grizli-v6.0'
         root = f'macs0416-{fi}-grizli-{version}'
 
-        xi, yi = np.cast[int](np.squeeze(full_wcs.all_world2pix([r0], [d0], 0)))
+        xi, yi = np.asarray(np.squeeze(full_wcs.all_world2pix([r0], [d0], 0)),dtype=int)
     
         wh = utils.get_wcs_slice_header(full_wcs,
                                         slice(xi-int(nnx*2048), xi+int(nnx*2048)),
@@ -1084,7 +1084,7 @@ NAXIS2  =                 4049                                                  
         root = f'macs1423-{fi}-grizli-v6.0' # stripe fixes, etc.
         root = f'macs1423-{fi}-grizli-{version}'
 
-        xi, yi = np.cast[int](np.squeeze(full_wcs.all_world2pix([r0], [d0], 0)))
+        xi, yi = np.asarray(np.squeeze(full_wcs.all_world2pix([r0], [d0], 0)),dtype=int)
     
         wh = utils.get_wcs_slice_header(full_wcs,
                                         slice(xi-int(nnx*2048), xi+int(nnx*2048)),
@@ -1137,7 +1137,7 @@ NAXIS2  =                 4049                                                  
         root = f'macs1149-{fi}-grizli-v6.1' # Chris level 1
         root = f'macs1149-{fi}-grizli-{version}'
 
-        xi, yi = np.cast[int](np.squeeze(full_wcs.all_world2pix([r0], [d0], 0)))
+        xi, yi = np.asarray(np.squeeze(full_wcs.all_world2pix([r0], [d0], 0)),dtype=int)
     
         wh = utils.get_wcs_slice_header(full_wcs,
                                         slice(xi-int(nnx*2048), xi+int(nnx*2048)),

--- a/grizli/aws/field_tiles.py
+++ b/grizli/aws/field_tiles.py
@@ -267,7 +267,7 @@ def split_tiles(root='abell2744-080-08.08', ref_tile=(8,8), filters=['visr','f12
     
     base = '_'.join(root.split('-')[:-1]).replace('+','_') + '_' + suffix[1:]
     
-    tx, ty = np.cast[int](root.split('-')[-1].split('.'))
+    tx, ty = np.asarray(root.split('-')[-1].split('.'),dtype=int)
 
     for iz, zoom in enumerate(zoom_levels):
         if iz > 0:

--- a/grizli/aws/lambda_handler.py
+++ b/grizli/aws/lambda_handler.py
@@ -304,7 +304,7 @@ def run_grizli_fit(event):
             # Split lists
             if ',' in event[k]:
                 try:
-                    event_kwargs[k] = np.cast[float](event[k].split(','))
+                    event_kwargs[k] = np.asarray(event[k].split(','),dtype=float)
                 except:
                     event_kwargs[k] = event[k].split(',')
             else:
@@ -541,7 +541,7 @@ def run_grizli_fit(event):
 
     # Is zr in the event dict?
     # if 'zr' in event:
-    #     zr = list(np.cast[float](event['zr']))
+    #     zr = list(np.asarray(event['zr'],dtype=float))
     # else:
     #     try:
     #         zr = np.load('fit_args.npy')[0]['zr']

--- a/grizli/aws/tile_mosaic.py
+++ b/grizli/aws/tile_mosaic.py
@@ -1076,7 +1076,7 @@ def send_all_tiles():
                          
         un = utils.Unique(keys, verbose=False)
         for v in tqdm(un.values):
-            tile, subx, suby = np.cast[int](v.split())
+            tile, subx, suby = np.asarray(v.split(),dtype=int)
             _wcs = tile_subregion_wcs(tile, subx, suby)
             ra, dec = _wcs.calc_footprint().mean(axis=0)
             tiles['ra'][un[v]] = ra

--- a/grizli/aws/utils.py
+++ b/grizli/aws/utils.py
@@ -43,12 +43,12 @@ def create_s3_index(path, output_file="index.html", extra_html="", upload=True, 
     if as_table:
         names = ['date', 'time', 'size', 'file']
         tab = grizli_utils.GTable(rows=rows, names=names)
-        size = np.cast[float](tab['size'])
+        size = np.asarray(tab['size'],dtype=float)
         tab['size'] = [f'{s/1.e6:.2f}' for s in size]
         tab['date'] = ['{date} {time}'.format(**row) for row in tab]
         tab.remove_column('time')
         
-        tab['size'] = np.cast[float](tab['size'])
+        tab['size'] = np.asarray(tab['size'],dtype=float)
         
         dl = []
         for file in tab['file']:

--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -2608,8 +2608,8 @@ def show_epochs_filter(ra, dec, size=4, filters=['F444W-CLEAR'], cleanup=True, v
     pscale = utils.get_wcs_pscale(wcs_list[0])
     
     # Set a pixel in detector space that will show up in the stack
-    xp, yp = np.squeeze(np.cast[int](wcs_list[0].all_world2pix([ra], [dec], 0)
-                                     + size/5/pscale))
+    xp, yp = np.squeeze(np.asarray(wcs_list[0].all_world2pix([ra], [dec], 0)
+                                     + size/5/pscale,dtype=int))
     try:
         for i in range(N):
             sci_list[i][yp, xp] = 10000

--- a/grizli/combine.py
+++ b/grizli/combine.py
@@ -179,7 +179,7 @@ def combine_flt(files=[], output='exposures_cmb.fits', grow=1,
         wht[(im['ERR'].data == 0) | (dq > 0) | (~np.isfinite(wht))] = 0
         wht[im['SCI'].data < -3*im['ERR'].data] = 0
 
-        wht = np.cast[np.float32](wht)
+        wht = np.asarray(wht,dtype=np.float32)
 
         exp_wcs = pywcs.WCS(im[1].header, relax=True)
         exp_wcs.pscale = utils.get_wcs_pscale(exp_wcs)
@@ -380,8 +380,8 @@ def split_pixel_quadrant(dx, dy, figure='quadrants.png', show=False):
     """
     from matplotlib.ticker import MultipleLocator
 
-    xq = np.cast[int](np.round((dx - np.floor(dx))*2)) % 2
-    yq = np.cast[int](np.round((dy - np.floor(dy))*2)) % 2
+    xq = np.asarray(np.round((dx - np.floor(dx))*2),dtype=int) % 2
+    yq = np.asarray(np.round((dy - np.floor(dy))*2),dtype=int) % 2
 
     # Test, show sub-pixel centers in a figure
     if figure:

--- a/grizli/ds9.py
+++ b/grizli/ds9.py
@@ -24,8 +24,8 @@ def show_open_targets():
     for i, target in enumerate(targets):
         targ = target.split()[-1]
         ds9 = DS9(target=targ)
-        ra, dec = np.cast[float](ds9.get('pan fk5').split())
-        xi, yi = np.cast[float](ds9.get('pan image').split())
+        ra, dec = np.asarray(ds9.get('pan fk5').split(),dtype=float)
+        xi, yi = np.asarray(ds9.get('pan image').split(),dtype=float)
         
         frame = ds9.get('frame')
         print(f'{i} {targ:14} {frame:>5} {ra:8.4f} {dec:8.4f} ({xi:5.0f} {yi:5.0f})')

--- a/grizli/fitting.py
+++ b/grizli/fitting.py
@@ -719,7 +719,7 @@ def run_all(id, t0=None, t1=None, fwhm=1200, zr=[0.65, 1.6], dz=[0.004, 0.0002],
         lz = np.log(1+fit['zgrid'])
         axz.plot(lz, np.log10(fit['pdf']), color='0.5', alpha=0.5)
         axz.set_xticks(np.log(1+ticks))
-        axz.set_xticklabels(np.cast[int](ticks))
+        axz.set_xticklabels(np.asarray(ticks,dtype=int))
         axz.set_xlim(lz.min(), lz.max())
     else:
         axz.plot(fit['zgrid'], np.log10(fit['pdf']), color='0.5', alpha=0.5)
@@ -2819,10 +2819,10 @@ class GroupFitter(object):
 
         dtype = np.float64
 
-        fit['zgrid'] = np.cast[dtype](zgrid)
-        fit['chi2'] = np.cast[dtype](chi2)
+        fit['zgrid'] = np.asarray(zgrid,dtype=dtype)
+        fit['chi2'] = np.asarray(chi2,dtype=dtype)
         if get_student_logpdf:
-            fit['student_logpdf'] = np.cast[dtype](logpdf)
+            fit['student_logpdf'] = np.asarray(logpdf,dtype=dtype)
 
         fit.meta['st_df'] = student_t_pars[0], 'Student-t df of spline fit'
         fit.meta['st_loc'] = student_t_pars[1], 'Student-t loc of spline fit'
@@ -2830,8 +2830,8 @@ class GroupFitter(object):
                               'Student-t scale of spline fit')
 
         #fit['chi2poly'] = chi2_poly
-        fit['coeffs'] = np.cast[dtype](coeffs)
-        fit['covar'] = np.cast[dtype](covar)
+        fit['coeffs'] = np.asarray(coeffs,dtype=dtype)
+        fit['covar'] = np.asarray(covar,dtype=dtype)
 
         fit = self._parse_zfit_output(fit, prior=prior)
 
@@ -3319,7 +3319,7 @@ class GroupFitter(object):
             lz = np.log(1+fit['zgrid'])
             axz.plot(lz, np.log10(fit['pdf']), color='k')
             axz.set_xticks(np.log(1+ticks))
-            axz.set_xticklabels(np.cast[int](ticks))
+            axz.set_xticklabels(np.asarray(ticks,dtype=int))
             axz.set_xlim(lz.min(), lz.max())
         else:
             axz.plot(fit['zgrid'], np.log10(fit['pdf']), color='k')
@@ -4524,7 +4524,7 @@ class GroupFitter(object):
             binned_spectrum['wave'] = w_g
             binned_spectrum['flux'] = flux_bin*(u.electron/u.second)
             binned_spectrum['err'] = np.sqrt(var_bin)*(u.electron/u.second)
-            binned_spectrum['npix'] = np.cast[int](n_bin)
+            binned_spectrum['npix'] = np.asarray(n_bin,int)
 
             binned_spectrum.meta['GRISM'] = (grism, 'Grism name')
             binned_spectrum.meta['BIN'] = (bin, 'Spectrum binning factor')

--- a/grizli/galfit/galfit.py
+++ b/grizli/galfit/galfit.py
@@ -615,7 +615,7 @@ class Galfitter(object):
 
         xy = self.wcs.all_world2pix([radec[0]], [radec[1]], 0)
         xy = np.array(xy).flatten()
-        xp = np.cast[int](np.round(xy))
+        xp = np.asarray(np.round(xy),dtype=int)
 
         slx, sly, wcs_slice = self.DPSF.get_driz_cutout(ra=radec[0], dec=radec[1], get_cutout=False, size=size)
         #drz_cutout = self.get_driz_cutout(ra=ra, dec=dec, get_cutout=True)
@@ -693,7 +693,7 @@ class Galfitter(object):
                 lines[il] = "H) 1    {0}   1    {1}   # Image region to fit (xmin xmax ymin ymax)\n".format(out_sh[1], out_sh[0])
 
             if line.startswith(' 1)'):
-                xy = np.cast[float](line.split()[1:3])
+                xy = np.asarray(line.split()[1:3],dtype=float)
                 lines[il] = ' 1) {0}  {1}  1 1  #  Position x, y\n'.format(xy[0]+slx.start, xy[1]+sly.start)
 
         fp = open('galfit.{0}.{1:05d}'.format(self.filter, id), 'w')

--- a/grizli/galfit/psf.py
+++ b/grizli/galfit/psf.py
@@ -235,7 +235,7 @@ class DrizzlePSF(object):
         TBD
         """
         xy = self.driz_wcs.all_world2pix(np.array([[ra, dec]]), 0)[0]
-        xyp = np.cast[int](np.round(xy))
+        xyp = np.asarray(np.round(xy),dtype=int)
         if N is None:
             N = int(np.round(size*self.wcs[self.flt_keys[0]].pscale/self.driz_pscale))
 
@@ -390,7 +390,7 @@ class DrizzlePSF(object):
                     print('{0}[SCI,{1}]'.format(file, ext))
 
                 xy = self.wcs[key].all_world2pix(np.array([[ra, dec]]), 0)[0]
-                xyp = np.cast[int](xy) #np.round(xy))  # +1
+                xyp = np.asarray(xy,dtype=int) #np.round(xy))  # +1
                 dx = xy[0] - int(xy[0]) + xphase
                 dy = xy[1] - int(xy[1]) + yphase
                 # dx = xy[0]-int(xy[0]) + 0.5

--- a/grizli/grismconf.py
+++ b/grizli/grismconf.py
@@ -93,7 +93,7 @@ class aXeConf():
             spl = line.split(';')[0].split('#')[0].split()
             param = spl[0]
             if len(spl) > 2:
-                value = np.cast[float](spl[1:])
+                value = np.asarray(spl[1:],dtype=float)
             else:
                 try:
                     value = float(spl[1])
@@ -135,12 +135,12 @@ class aXeConf():
                 self.dxlam[beam] = np.arange(self.conf['BEAM{0}'.format(beam)].min(), self.conf['BEAM{0}'.format(beam)].max(), dtype=int)
                 self.nx[beam] = int(self.dxlam[beam].max()-self.dxlam[beam].min())+1
                 self.sens[beam] = Table.read('{0}/{1}'.format(os.path.dirname(self.conf_file), self.conf['SENSITIVITY_{0}'.format(beam)]))
-                #self.sens[beam].wave = np.cast[np.double](self.sens[beam]['WAVELENGTH'])
-                #self.sens[beam].sens = np.cast[np.double](self.sens[beam]['SENSITIVITY'])
+                #self.sens[beam].wave = np.asarray(self.sens[beam]['WAVELENGTH'],dtype=np.double)
+                #self.sens[beam].sens = np.asarray(self.sens[beam]['SENSITIVITY'],dtype=np.double)
 
                 # Need doubles for interpolating functions
                 for col in self.sens[beam].colnames:
-                    data = np.cast[np.double](self.sens[beam][col])
+                    data = np.asarray(self.sens[beam][col],dtype=np.double)
                     self.sens[beam].remove_column(col)
                     self.sens[beam].add_column(Column(data=data, name=col))
 
@@ -152,9 +152,9 @@ class aXeConf():
                     if self.conf['SENSITIVITY_B'] == 'WFC3.IR.G141.0th.sens.1.fits':
                         self.sens[beam]['SENSITIVITY'] *= 2
 
-                # wave = np.cast[np.double](self.sens[beam]['WAVELENGTH'])
-                # sens = np.cast[np.double](self.sens[beam]['SENSITIVITY']
-                # self.sens[beam]['WAVELENGTH'] = np.cast[np.double](self.sens[beam]['WAVELENGTH'])
+                # wave = np.asarray(self.sens[beam]['WAVELENGTH'],dtype=np.double)
+                # sens = np.asarray(self.sens[beam]['SENSITIVITY'],dtype=np.double)
+                # self.sens[beam]['WAVELENGTH'] = np.asarray(self.sens[beam]['WAVELENGTH'],dtype=np.double)
                 # self.sens[beam]['SENSITIVITY'] = )
 
         self.beams.sort()
@@ -1194,7 +1194,7 @@ class TransformGrismconf(object):
             elif trace_axis == '-y':
                 xarr = -1*dy
 
-            xarr = np.cast[int](np.round(xarr))
+            xarr = np.asarray(np.round(xarr),dtype=int)
 
             #self.beams.append(beam)
             self.dxlam[beam] = np.arange(xarr.min(), xarr.max(), dtype=int)

--- a/grizli/model.py
+++ b/grizli/model.py
@@ -252,7 +252,7 @@ class GrismDisperser(object):
         self.direct = direct
         self.sh = self.direct.shape
         if self.direct.dtype is not np.float32:
-            self.direct = np.cast[np.float32](self.direct)
+            self.direct = np.asarray(self.direct,dtype=np.float32)
 
         # Segmentation image, defaults to all zeros
         if segmentation is None:
@@ -374,7 +374,7 @@ class GrismDisperser(object):
 
         # Integer trace
         # Add/subtract 20 for handling int of small negative numbers
-        dyc = np.cast[int](self.ytrace_beam+20)-20+1
+        dyc = np.asarray(self.ytrace_beam+20,dtype=int)-20+1
 
         # Account for pixel centering of the trace
         self.yfrac_beam = self.ytrace_beam - np.floor(self.ytrace_beam)
@@ -480,7 +480,7 @@ class GrismDisperser(object):
 
         # Integer trace
         # Add/subtract 20 for handling int of small negative numbers
-        dyc = np.cast[int](self.ytrace_beam+20)-20+1
+        dyc = np.asarray(self.ytrace_beam+20,dtype=int)-20+1
 
         # Account for pixel centering of the trace
         self.yfrac_beam = self.ytrace_beam - np.floor(self.ytrace_beam)
@@ -771,7 +771,7 @@ Error: `thumb` must have the same dimensions as the direct image! ({0:d},{1:d})
 
         All are optionally binned in wavelength if `bin` > 1.
         """
-        dy = np.cast[int](np.round(self.ytrace+dy0))
+        dy = np.asarray(np.round(self.ytrace+dy0),dtype=int)
         aper = np.zeros_like(self.model)
         y0 = self.sh_beam[0] // 2
         for d in range(-r, r+1):
@@ -929,7 +929,7 @@ Error: `thumb` must have the same dimensions as the direct image! ({0:d},{1:d})
             xlam = np.arange(limits[0], limits[1], limits[2])
             xpix = np.interp(xlam, self.lam/wscale, xarr)
         else:
-            xlam = np.unique(np.cast[int](self.lam / 1.e4*10)/10.)
+            xlam = np.unique(np.asarray(self.lam / 1.e4*10,dtype=int)/10.)
             xpix = np.interp(xlam, self.lam/wscale, xarr)
 
         if mpl_axis is None:
@@ -1393,7 +1393,7 @@ class ImageData(object):
             if ('REF', sci_extn) in hdulist:
                 ref_h = hdulist['REF', sci_extn].header
                 ref_data = hdulist['REF', sci_extn].data/ref_h['PHOTFLAM']
-                ref_data = np.cast[np.float32](ref_data)
+                ref_data = np.asarray(ref_data,dtype=np.float32)
 
                 ref_file = ref_h['REF_FILE']
                 ref_photflam = 1.
@@ -1405,13 +1405,13 @@ class ImageData(object):
                 ref_data = None
 
             if ('SCI', sci_extn) in hdulist:
-                sci = np.cast[np.float32](hdulist['SCI', sci_extn].data)
-                err = np.cast[np.float32](hdulist['ERR', sci_extn].data)
-                dq = np.cast[np.int16](hdulist['DQ', sci_extn].data)
+                sci = np.asarray(hdulist['SCI', sci_extn].data,dtype=np.float32)
+                err = np.asarray(hdulist['ERR', sci_extn].data,dtype=np.float32)
+                dq = np.asarray(hdulist['DQ', sci_extn].data,dtype=np.int16)
                 
                 if ('MED',sci_extn) in hdulist:
                     mkey = ('MED',sci_extn)
-                    med_filter = np.cast[np.float32](hdulist[mkey].data)
+                    med_filter = np.asarray(hdulist[mkey].data,dtype=np.float32)
                     
                     if restore_medfilt:
                         print('xxx put med filter back in')
@@ -1419,7 +1419,7 @@ class ImageData(object):
                         
                 if ('BKG',sci_extn) in hdulist:
                     mkey = ('BKG',sci_extn)
-                    bkg_array = np.cast[np.float32](hdulist[mkey].data)
+                    bkg_array = np.asarray(hdulist[mkey].data,dtype=np.float32)
 
                 base_extn = ('SCI', sci_extn)
 
@@ -1955,7 +1955,7 @@ class ImageData(object):
         yflt = [-extra, -extra, naxis[1]+extra, naxis[1]+extra]
 
         raflt, deflt = self.wcs.all_pix2world(xflt, yflt, 0)
-        xref, yref = np.cast[int](ref_wcs.all_world2pix(raflt, deflt, 0))
+        xref, yref = np.asarray(ref_wcs.all_world2pix(raflt, deflt, 0),dtype=int)
         ref_naxis = [hdu.header['NAXIS1'], hdu.header['NAXIS2']]
 
         # Slices of the reference image
@@ -2005,7 +2005,7 @@ class ImageData(object):
                 naxis[1]+self.pad[0], naxis[1]+self.pad[0]]
 
         raflt, deflt = self.wcs.all_pix2world(xflt, yflt, 0)
-        xref, yref = np.cast[int](ref_wcs.all_world2pix(raflt, deflt, 0))
+        xref, yref = np.asarray(ref_wcs.all_world2pix(raflt, deflt, 0),dtype=int)
         ref_naxis = [hdu.header['NAXIS1'], hdu.header['NAXIS2']]
 
         pad_min = np.minimum(xref.min(), yref.min())
@@ -2077,8 +2077,8 @@ class ImageData(object):
 
         #ref = pyfits.open(refimage)
         if hdu.data.dtype.type != np.float32:
-            #hdu.data = np.cast[np.float32](hdu.data)
-            refdata = np.cast[np.float32](hdu.data)
+            #hdu.data = np.asarray(hdu.data,dtype=np.float32)
+            refdata = np.asarray(hdu.data,dtype=np.float32)
         else:
             refdata = hdu.data
 
@@ -2086,7 +2086,7 @@ class ImageData(object):
             hdu.header.remove('ORIENTAT')
 
         if segmentation:
-            seg_ones = np.cast[np.float32](refdata > 0)-1
+            seg_ones = np.asarray(refdata > 0,dtype=np.float32)-1
 
         ref_wcs = pywcs.WCS(hdu.header, relax=True)
         flt_wcs = self.wcs.copy()
@@ -2772,7 +2772,7 @@ class GrismFLT(object):
 
         # TBD: compute something like a cross-correlation offset
         # between blotted reference and the direct image itself
-        self.direct.data['REF'] = np.cast[np.float32](blotted_ref)
+        self.direct.data['REF'] = np.asarray(blotted_ref,dtype=np.float32)
         # print self.direct.data['REF'].shape, self.direct.ref_photflam
 
         self.direct.data['REF'] *= self.direct.ref_photflam
@@ -4410,11 +4410,11 @@ class BeamCutout(object):
         tab = utils.GTable()
         tab.meta['CONFFILE'] = os.path.basename(self.beam.conf.conf_file)
 
-        tab['wavelength'] = np.cast[dtype](self.beam.lam*u.Angstrom)
-        tab['trace'] = np.cast[dtype](self.beam.ytrace + self.beam.sh_beam[0]/2 - self.beam.ycenter)
+        tab['wavelength'] = np.asarray(self.beam.lam*u.Angstrom,dtype=dtype)
+        tab['trace'] = np.asarray(self.beam.ytrace + self.beam.sh_beam[0]/2 - self.beam.ycenter,dtype=dtype)
 
         sens_units = u.erg/u.second/u.cm**2/u.Angstrom/(u.electron/u.second)
-        tab['sensitivity'] = np.cast[dtype](self.beam.sensitivity*sens_units)
+        tab['sensitivity'] = np.asarray(self.beam.sensitivity*sens_units,dtype=dtype)
 
         return tab
 
@@ -4483,7 +4483,7 @@ class BeamCutout(object):
 
         hdu = pyfits.HDUList([pyfits.PrimaryHDU(header=h0)])
         hdu.extend(self.direct.get_HDUList(extver=1))
-        hdu.append(pyfits.ImageHDU(data=np.cast[np.int32](self.beam.seg),
+        hdu.append(pyfits.ImageHDU(data=np.asarray(self.beam.seg,dtype=np.int32),
                                    header=hdu[-1].header, name='SEG'))
 
         # 2D grism spectra
@@ -4515,7 +4515,7 @@ class BeamCutout(object):
                                    name='CONTAM'))
 
         if include_model:
-            hdu.append(pyfits.ImageHDU(data=np.cast[np.float32](self.model),
+            hdu.append(pyfits.ImageHDU(data=np.asarray(self.model,dtype=np.float32),
                                        header=hdu[-1].header, name='MODEL'))
 
         if get_trace_table:

--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -1545,7 +1545,7 @@ class GroupFLT():
 #     beam_ra = beams_image[0].header['RA']
 #     beam_dec = beams_image[0].header['DEC']
 #
-#     xy = np.cast[int](np.round(ref_wcs.all_world2pix([beam_ra], [beam_dec], 0))).flatten()
+#     xy = np.asarray(np.round(ref_wcs.all_world2pix([beam_ra], [beam_dec], 0)),dtype=int).flatten()
 #
 #     slx = slice(xy[0]-cutout, xy[0]+cutout)
 #     sly = slice(xy[1]-cutout, xy[1]+cutout)
@@ -1896,7 +1896,7 @@ class MultiBeam(GroupFitter):
 
         self.scif = np.hstack([b.scif for b in self.beams])
         self.idf = np.hstack([b.scif*0+ib for ib, b in enumerate(self.beams)])
-        self.idf = np.cast[int](self.idf)
+        self.idf = np.asarray(self.idf,dtype=int)
 
         #self.ivarf = 1./(1/self.ivarf + (self.sys_err*self.scif)**2)
         self.ivarf[~np.isfinite(self.ivarf)] = 0
@@ -2036,7 +2036,7 @@ class MultiBeam(GroupFitter):
 
         hdu = pyfits.open(beam_file, lazy_load_hdus=False)
         N = hdu[0].header['COUNT']
-        Next = np.cast[int](hdu[0].header.comments['COUNT'].split())
+        Next = np.asarray(hdu[0].header.comments['COUNT'].split(),dtype=int)
 
         i0 = 1
         self.beams = []
@@ -2220,7 +2220,7 @@ class MultiBeam(GroupFitter):
 
         beam_ra, beam_dec = self.ra, self.dec
 
-        xy = np.cast[int](np.round(ref_wcs.all_world2pix([beam_ra], [beam_dec], 0))).flatten()
+        xy = np.asarray(np.round(ref_wcs.all_world2pix([beam_ra], [beam_dec], 0)),dtype=int).flatten()
 
         sh = ref_data.shape
         slx = slice(np.maximum(xy[0]-cutout, 0),
@@ -4765,7 +4765,7 @@ def drizzle_2d_spectrum(beams, data=None, wlimit=[1.05, 1.75], dlam=50,
 
         # Downweight contamination
         # wht = 1/beam.ivar + (fcontam*beam.contam)**2
-        # wht = np.cast[np.float32](1/wht)
+        # wht = np.asarray(1/wht,dtype=np.float32)
         # wht[~np.isfinite(wht)] = 0.
 
         contam_weight = np.exp(-(fcontam*np.abs(beam.contam)*np.sqrt(beam.ivar)))
@@ -5064,7 +5064,7 @@ def drizzle_to_wavelength(beams, wcs=None, ra=0., dec=0., wave=1.e4, size=5, pix
         # Downweight contamination
         if fcontam > 0:
             # wht = 1/beam.ivar + (fcontam*beam.contam)**2
-            # wht = np.cast[np.float32](1/wht)
+            # wht = np.asarray(1/wht,dtype=np.float32)
             # wht[~np.isfinite(wht)] = 0.
 
             contam_weight = np.exp(-(fcontam*np.abs(beam.contam)*np.sqrt(beam.ivar)))
@@ -5122,7 +5122,7 @@ def drizzle_to_wavelength(beams, wcs=None, ra=0., dec=0., wave=1.e4, size=5, pix
 
         if direct_extension == 'REF':
             thumb = beam.direct['REF']
-            thumb_wht = np.cast[np.float32]((thumb != 0)*1)
+            thumb_wht = np.asarray((thumb != 0)*1,dtype=np.float32)
         else:
             thumb = beam.direct[direct_extension]  # /beam.direct.photflam
             thumb_wht = 1./(beam.direct.data['ERR']/beam.direct.photflam)**2
@@ -5581,7 +5581,7 @@ def drizzle_2d_spectrum_wcs(beams, data=None, wlimit=[1.05, 1.75], dlam=50,
 
         # Downweight contamination
         # wht = 1/beam.ivar + (fcontam*beam.contam)**2
-        # wht = np.cast[np.float32](1/wht)
+        # wht = np.asarray(1/wht,dtype=np.float32)
         # wht[~np.isfinite(wht)] = 0.
 
         contam_weight = np.exp(-(fcontam*np.abs(beam.contam)*np.sqrt(beam.ivar)))

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -2331,13 +2331,13 @@ def preprocess(field_root='j142724+334246',  HOME_PATH='/Volumes/Pegasus/Grizli/
         else:
             filters.append(vspl[-1])
 
-    fwave = np.cast[float]([f.replace('f1', 'f10'). \
+    fwave = np.asarray([f.replace('f1', 'f10'). \
                               replace('f098m', 'f0980m'). \
                               replace('lp', 'w'). \
                               replace('gr','g'). \
                               replace('grism','g410'). \
                               replace('fq', 'f')[1:-1] 
-                            for f in filters])
+                            for f in filters],dtype=float)
     
     if len(np.unique(fwave)) > 1:
         sort_idx = np.argsort(fwave)[::-1]
@@ -2574,7 +2574,7 @@ def mask_IR_psf_spikes(visit={}, mag_lim=17, cat=None, cols=['mag_auto', 'ra', '
                     xr = _mat.dot(xx).T
 
                     x = xr+xy[i, :]
-                    xp = np.cast[int](np.round(x))
+                    xp = np.asarray(np.round(x),dtype=int)
                     #plt.plot(xp[:,0], xp[:,1], color='pink', alpha=0.3, linewidth=5)
 
                     for j in range(-dy, dy+1):
@@ -2772,7 +2772,7 @@ def multiband_catalog(field_root='j142724+334246', threshold=1.8, detection_back
     #source_xy = tab['X_IMAGE'], tab['Y_IMAGE']
     if aper_segmask:
         seg_data = pyfits.open('{0}_seg.fits'.format(detection_root))[0].data
-        seg_data = np.cast[np.int32](seg_data)
+        seg_data = np.asarray(seg_data,dtype=np.int32)
 
         aseg, aseg_id = seg_data, tab['NUMBER']
 
@@ -3662,8 +3662,8 @@ def refine_model_with_fits(field_root='j142724+334246', grp=None, master_files=N
             sp = utils.GTable(hdu['TEMPL'].data)
 
             dt = np.float
-            wave = np.cast[dt](sp['wave'])  # .byteswap()
-            flux = np.cast[dt](sp[spectrum])  # .byteswap()
+            wave = np.asarray(sp['wave'],dtype=dt)  # .byteswap()
+            flux = np.asarray(sp[spectrum],dtype=dt)  # .byteswap()
             grp.compute_single_model(int(id), mag=19, size=-1, store=False,
                                      spectrum_1d=[wave, flux], is_cgs=True,
                                      get_beams=None, in_place=True)
@@ -5405,7 +5405,7 @@ def get_rgb_filters(filter_list, force_ir=False, pure_sort=False):
                 p = for_sort.pop(k)
 
     so = np.argsort(list(for_sort.values()))
-    waves = np.cast[float]([for_sort[f][1:] for f in for_sort])
+    waves = np.asarray([for_sort[f][1:] for f in for_sort],dtype=float)
 
     # Reddest
     rfilt = use_filters[so[-1]]
@@ -5788,7 +5788,7 @@ def field_rgb(root='j010514+021532', xsize=8, output_dpi=None, HOME_PATH='./', s
         
         image = norm(image).filled(0)
         if invert:
-            image = 255 - np.clip(np.cast[int](image*255), 0, 255)
+            image = 255 - np.clip(np.asarray(image*255,dtype=int), 0, 255)
                     
     if fill_black:
         image[rmsk,0] = 0
@@ -6069,7 +6069,7 @@ def make_rgb_thumbnails(root='j140814+565638', ids=None, maglim=21,
             blot_seg = utils.blot_nearest_exact(seg_data, seg_wcs, th_wcs,
                                        stepsize=-1, scale_by_pixel_area=False)
 
-            rnd_seg = rnd_ids[np.cast[int](blot_seg)]*1.
+            rnd_seg = rnd_ids[np.asarray(blot_seg,dtype=int)]*1.
             th_ids = np.unique(blot_seg)
 
             sh = th[0].data.shape
@@ -6106,7 +6106,7 @@ def make_rgb_thumbnails(root='j140814+565638', ids=None, maglim=21,
             plt.close(fig)
 
             # Append to thumbs file
-            seg_hdu = pyfits.ImageHDU(data=np.cast[int](blot_seg), name='SEG')
+            seg_hdu = pyfits.ImageHDU(data=np.asarray(blot_seg,dtype=int), name='SEG')
             th.append(seg_hdu)
             th.writeto('{0}.thumb.fits'.format(label), overwrite=True,
                          output_verify='fix')

--- a/grizli/pipeline/photoz.py
+++ b/grizli/pipeline/photoz.py
@@ -432,13 +432,13 @@ def show_from_ds9(ds9, self, zout, use_sky=True, **kwargs):
     import numpy as np
 
     if use_sky:
-        xy = np.cast[float](ds9.get('pan fk5').split())
+        xy = np.asarray(ds9.get('pan fk5').split(),dtype=float)
         cosd = np.cos(xy[1]/180*np.pi)
         r = np.sqrt((self.cat['ra']-xy[0])**2*cosd**2 + (self.cat['dec']-xy[1])**2)*3600
         runit = 'arcsec'
 
     if (not use_sky) | (xy.sum() == 0):
-        xy = np.cast[float](ds9.get('pan image').split())
+        xy = np.asarray(ds9.get('pan image').split(),dtype=float)
         r = np.sqrt((self.cat['x_image']-xy[0])**2 + (self.cat['y_image']-xy[1])**2)
         runit = 'pix'
 

--- a/grizli/pipeline/reprocess.py
+++ b/grizli/pipeline/reprocess.py
@@ -151,7 +151,7 @@ def inspect(root='grizli', force=False):
 
         ramp_file = tab['images'][i].replace('_ramp.png', '_ramp.dat')
         #sn_pop = mywfc3.inspect.check_background_SN(ramp_file=ramp_file, show=False)
-        #pop_reads = np.cast[int](np.unique(np.hstack((pop_reads, sn_pop))))
+        #pop_reads = np.asarray(np.unique(np.hstack((pop_reads, sn_pop))),dtype=int)
         #pop_reads = list(pop_reads)
 
         flt = raw.replace('_raw', '_flt')

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -1127,7 +1127,7 @@ def align_drizzled_image(root='',
     for iter in range(NITER):
         #print('xx iter {0} {1}'.format(iter, NITER))
         xy = np.array(drz_wcs.all_world2pix(rd_ref, pix_origin))
-        pix = np.cast[int](np.round(xy)).T
+        pix = np.asarray(np.round(xy),dtype=int).T
 
         # Find objects where drz pixels are non-zero
         okp = (pix[0, :] > 0) & (pix[1, :] > 0)
@@ -1941,7 +1941,7 @@ def make_SEP_catalog(root='',
             wcs_header[k] = drz_im[0].header[k]
 
     if isinstance(phot_apertures, str):
-        apertures = np.cast[float](phot_apertures.replace(',', '').split())
+        apertures = np.asarray(phot_apertures.replace(',', '').split(),dtype=float)
     else:
         apertures = []
         for ap in phot_apertures:
@@ -1977,7 +1977,7 @@ def make_SEP_catalog(root='',
     except:
         pass
 
-    data_mask = np.cast[data.dtype](mask)
+    data_mask = np.asarray(mask,dtype=data.dtype)
 
     if get_background | (err_scale < 0) | (use_bkg_err):
 
@@ -2401,7 +2401,7 @@ def get_seg_iso_flux(data, seg, tab, err=None, fill=None, verbose=0):
 
     iso_flux = ids*0.
     iso_err = ids*0.
-    iso_area = np.cast[int](ids*0)
+    iso_area = np.asarray(ids*0,dtype=int)
 
     xmin = np.clip(tab['xmin'], 0, sh[1])
     xmax = np.clip(tab['xmax'], 0, sh[1])
@@ -2409,7 +2409,7 @@ def get_seg_iso_flux(data, seg, tab, err=None, fill=None, verbose=0):
     ymax = np.clip(tab['ymax'], 0, sh[0])
 
     if fill is not None:
-        filled_data = np.cast[fill.dtype](seg*0)
+        filled_data = np.asarray(seg*0,dtype=fill.dtype)
 
     for ii, id in enumerate(ids):
 
@@ -7012,8 +7012,8 @@ def find_single_image_CRs(visit, simple_mask=False, with_ctx_mask=True,
         ctx = pyfits.open(ctx_files[0])
         bits = np.log2(ctx[0].data)
         mask = ctx[0].data == 0
-        #single_image = np.cast[np.float32]((np.cast[int](bits) == bits) & (~mask))
-        single_image = np.cast[float]((np.cast[int](bits) == bits) & (~mask))
+        #single_image = np.asarray((np.asarray(bits,dtype=int) == bits) & (~mask),dtype=np.float32)
+        single_image = np.asarray((np.asarray(bits,dtype=int) == bits) & (~mask),dtype=float)
         ctx_wcs = pywcs.WCS(ctx[0].header)
         ctx_wcs.pscale = utils.get_wcs_pscale(ctx_wcs)
         ctx.close()
@@ -7427,12 +7427,12 @@ def drizzle_overlaps(exposure_groups, parse_visits=False, check_overlaps=True, m
             
             if driz_cr_snr_grow != 1:
                 spl = driz_cr_snr.split()
-                new_snr = np.cast[float](spl)*driz_cr_snr_grow
+                new_snr = np.asarray(spl,dtype=float)*driz_cr_snr_grow
                 driz_cr_snr = ' '.join([f'{val:.2f}' for val in new_snr])
             
             if driz_cr_scale_grow != 1:
                 spl = driz_cr_scale.split()
-                new_scale = np.cast[float](spl)*driz_cr_scale_grow
+                new_scale = np.asarray(spl,dtype=float)*driz_cr_scale_grow
                 driz_cr_scale = ' '.join([f'{val:.2f}' for val in new_scale])
             
         if bits is None:
@@ -7620,9 +7620,9 @@ def manual_alignment(visit, ds9, reference=None, reference_catalogs=['SDSS', 'PS
         print('Input detected ({0}).  Abort.'.format(x))
         return False
 
-    x0 = np.cast[float](ds9.get('pan image').split())
+    x0 = np.asarray(ds9.get('pan image').split(),dtype=float)
     x = input('pan to object in region: ')
-    x1 = np.cast[float](ds9.get('pan image').split())
+    x1 = np.asarray(ds9.get('pan image').split(),dtype=float)
 
     print('Saved {0}.align_guess'.format(visit['product']))
 

--- a/grizli/stack.py
+++ b/grizli/stack.py
@@ -208,7 +208,7 @@ class StackFitter(GroupFitter):
                     self.extend(extra)
 
         self.idf = np.hstack([b.scif*0+ib for ib, b in enumerate(self.beams)])
-        self.idf = np.cast[int](self.idf)
+        self.idf = np.asarray(self.idf,dtype=int)
 
         # if eazyp is not None:
         #     self.eazyp = eazyp

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -435,13 +435,13 @@ def blot_nearest_exact(in_data, in_wcs, out_wcs, verbose=True, stepsize=-1,
                                           stepsize)
         xf, yf = mapping(xo, yo)
 
-    xi, yi = np.cast[int](np.round(xf)), np.cast[int](np.round(yf))
+    xi, yi = np.asarray(np.round(xf),dtype=int), np.asarray(np.round(yf),dtype=int)
 
     m2 = (xi >= 0) & (yi >= 0) & (xi < in_sh[1]) & (yi < in_sh[0])
     xi, yi, xf, yf, xo, yo = xi[m2], yi[m2], xf[m2], yf[m2], xo[m2], yo[m2]
 
     out_data = np.ones(out_sh, dtype=np.float64)*fill_value
-    status = pixel_map_c(np.cast[np.float64](in_data), xi, yi, out_data, xo, yo)
+    status = pixel_map_c(np.asarray(in_data,dtype=np.float64), xi, yi, out_data, xo, yo)
 
     # Fill empty
     func = nd.maximum_filter
@@ -999,7 +999,7 @@ def split_visit(visit, visit_split_shift=1.5, max_dt=6./24, path='../RAW'):
     crval1 = np.array([im[1].header['CRVAL1'] for im in ims])
     crval2 = np.array([im[1].header['CRVAL2'] for im in ims])
     expstart = np.array([im[0].header['EXPSTART'] for im in ims])
-    dt = np.cast[int]((expstart-expstart[0])/max_dt)
+    dt = np.asarray((expstart-expstart[0])/max_dt,dtype=int)
     
     for im in ims:
         im.close()
@@ -1007,8 +1007,8 @@ def split_visit(visit, visit_split_shift=1.5, max_dt=6./24, path='../RAW'):
     dx = (crval1 - crval1[0])*60*np.cos(crval2[0]/180*np.pi)
     dy = (crval2 - crval2[0])*60
 
-    dxi = np.cast[int](np.round(dx/visit_split_shift))
-    dyi = np.cast[int](np.round(dy/visit_split_shift))
+    dxi = np.asarray(np.round(dx/visit_split_shift),dtype=int)
+    dyi = np.asarray(np.round(dy/visit_split_shift),dtype=int)
     keys = dxi*100+dyi+1000*dt
 
     un = np.unique(keys)
@@ -1746,7 +1746,7 @@ def detect_with_photutils(sci, err=None, dq=None, seg=None, detect_thresh=2.,
                               filter_kernel=kernel)
 
         grow = nd.maximum_filter(segm.data, grow_seg)
-        seg = np.cast[np.float32](grow)
+        seg = np.asarray(grow,dtype=np.float32)
     else:
         # Use the supplied segmentation image
         segm = SegmentationImage(seg)
@@ -2447,14 +2447,14 @@ class SpectrumTemplate(object):
         """
         self.wave = wave
         if wave is not None:
-            self.wave = np.cast[np.float64](wave)
+            self.wave = np.asarray(wave,dtype=np.float64)
 
         self.flux = flux
         if flux is not None:
-            self.flux = np.cast[np.float64](flux)
+            self.flux = np.asarray(flux,dtype=np.float64)
 
         if err is not None:
-            self.err = np.cast[np.float64](err)
+            self.err = np.asarray(err,dtype=np.float64)
         else:
             self.err = None
 
@@ -5081,9 +5081,9 @@ def make_wcsheader(ra=40.07293, dec=-1.6137748, size=2, pixscale=0.1, get_hdu=Fa
         cdelt = [pixscale[0]/3600., pixscale[1]/3600.]
 
     if np.isscalar(size):
-        npix = np.cast[int](np.round([size/pixscale, size/pixscale]))
+        npix = np.asarray(np.round([size/pixscale, size/pixscale]),dtype=int)
     else:
-        npix = np.cast[int](np.round([size[0]/pixscale, size[1]/pixscale]))
+        npix = np.asarray(np.round([size[0]/pixscale, size[1]/pixscale]),dtype=int)
 
     hout = pyfits.Header()
     hout['CRPIX1'] = (npix[0]-1)/2+1
@@ -5253,7 +5253,7 @@ def make_maximal_wcs(files, pixel_scale=None, get_hdu=True, pad=90, verbose=True
                 else:
                     group_poly = group_poly.union(p_i)
                  
-            x0, y0 = np.cast[float](group_poly.centroid.xy)[:, 0]
+            x0, y0 = np.asarray(group_poly.centroid.xy,dtype=float)[:, 0]
             if verbose:
                 msg = '{0:>3d}/{1:>3d}: {2}[SCI,{3}]  {4:>6.2f}'
                 print(msg.format(i, len(files), file, chip+1,
@@ -5261,8 +5261,8 @@ def make_maximal_wcs(files, pixel_scale=None, get_hdu=True, pad=90, verbose=True
                                  )
                       )
 
-    px = np.cast[float](group_poly.convex_hull.boundary.xy).T
-    #x0, y0 = np.cast[float](group_poly.centroid.xy)[:,0]
+    px = np.asarray(group_poly.convex_hull.boundary.xy,dtype=float).T
+    #x0, y0 = np.asarray(group_poly.centroid.xy,dtype=float)[:,0]
 
     x0 = (px.max(axis=0)+px.min(axis=0))/2.
 
@@ -7460,8 +7460,8 @@ class EffectivePSF:
             rx -= 1
             ry -= 1
 
-            nx = np.clip(np.cast[int](rx), 0, iX-1)
-            ny = np.clip(np.cast[int](ry), 0, iY-1)
+            nx = np.clip(np.asarray(rx,dtype=int), 0, iX-1)
+            ny = np.clip(np.asarray(ry,dtype=int), 0, iY-1)
 
             # print x, y, rx, ry, nx, ny
 
@@ -8767,7 +8767,7 @@ def catalog_area(ra=[], dec=[], make_plot=True, NMAX=5000, buff=0.8, verbose=Tru
     #pbuff = 1
 
     if len(ra) > NMAX:
-        rnd_idx = np.unique(np.cast[int](np.round(np.random.rand(NMAX)*len(ra))))
+        rnd_idx = np.unique(np.asarray(np.round(np.random.rand(NMAX)*len(ra)),dtype=int))
     else:
         rnd_idx = np.arange(len(ra))
 


### PR DESCRIPTION
NumPy 2.0.0 has been released, removing np.cast. This should fix compliance with NumPy.
This is won't break `grizli["jwst"]` for now as the JWST pipeline is pinned to NumPy < 2.0.0 but this may have current consequences for HST reduction, and will eventually affect JWST when they upgrade to newer NumPy version. 