### PR TITLE
New CI Tests for Python 3.11 and 3.12

### DIFF
--- a/.github/workflows/python-package-ero.yml
+++ b/.github/workflows/python-package-ero.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/python-package-with-jwst.yml
+++ b/.github/workflows/python-package-with-jwst.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
@@ -32,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11', '3.12']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v4

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     scikit-learn
     scipy>=1.6
     sep
+    setuptools
     shapely
     sregion>=1.2.2
     stwcs


### PR DESCRIPTION
Added CI tests for latest Python versions that grizli can support. To address #237.