### PR TITLE
Support for Context Maps

### DIFF
--- a/grizli/aws/aws_drizzler.py
+++ b/grizli/aws/aws_drizzler.py
@@ -531,7 +531,7 @@ def segmentation_figure(label, cat, segfile):
     th.close()
 
 
-def drizzle_images(label='macs0647-jd1', ra=101.9822125, dec=70.24326667, pixscale=0.1, size=10, wcs=None, pixfrac=0.33, kernel='square', theta=0, half_optical_pixscale=True, filters=['f160w', 'f140w', 'f125w', 'f105w', 'f110w', 'f098m', 'f850lp', 'f814w', 'f775w', 'f606w', 'f475w', 'f555w', 'f600lp', 'f390w', 'f350lp'], skip=None, remove=True, rgb_params=RGB_PARAMS, master='grizli-v1-19.12.04', aws_bucket='s3://grizli/CutoutProducts/', scale_ab=21, thumb_height=2.0, sync_fits=True, subtract_median=True, include_saturated=True, include_ir_psf=False, oversample_psf=False, show_filters=['visb', 'visr', 'y', 'j', 'h'], combine_similar_filters=True, single_output=True, aws_prep_dir=None, make_segmentation_figure=False, get_dict=False, dryrun=False, thumbnail_ext='png', **kwargs):
+def drizzle_images(label='macs0647-jd1', ra=101.9822125, dec=70.24326667, pixscale=0.1, size=10, wcs=None, pixfrac=0.33, kernel='square', theta=0, half_optical_pixscale=True, filters=['f160w', 'f140w', 'f125w', 'f105w', 'f110w', 'f098m', 'f850lp', 'f814w', 'f775w', 'f606w', 'f475w', 'f555w', 'f600lp', 'f390w', 'f350lp'], skip=None, remove=True, rgb_params=RGB_PARAMS, master='grizli-v1-19.12.04', aws_bucket='s3://grizli/CutoutProducts/', scale_ab=21, thumb_height=2.0, sync_fits=True, subtract_median=True, include_saturated=True, include_ir_psf=False, oversample_psf=False, show_filters=['visb', 'visr', 'y', 'j', 'h'], combine_similar_filters=True, single_output=True, aws_prep_dir=None, make_segmentation_figure=False, get_dict=False, dryrun=False, thumbnail_ext='png', write_ctx=False, **kwargs):
     """
     label='cp561356'; ra=150.208875; dec=1.850241667; size=40; filters=['f160w','f814w', 'f140w','f125w','f105w','f606w','f475w']
 
@@ -799,7 +799,7 @@ def drizzle_images(label='macs0647-jd1', ra=101.9822125, dec=70.24326667, pixsca
             continue
 
         elif status is not None:
-            sci, wht, var, outh, filt_dict[filt], wcs_tab = status
+            sci, wht, var, ctx, outh, filt_dict[filt], wcs_tab = status
 
             if subtract_median:
                 #med = np.median(sci[sci != 0])
@@ -825,6 +825,10 @@ def drizzle_images(label='macs0647-jd1', ra=101.9822125, dec=70.24326667, pixsca
             pyfits.writeto('{0}-{1}_drz_wht.fits'.format(label, filt),
                            data=wht, header=outh, overwrite=True,
                            output_verify='fix')
+            if write_ctx:
+                pyfits.writeto('{0}-{1}_drz_ctx.fits'.format(label, filt),
+                            data=ctx, header=outh, overwrite=True,
+                            output_verify='fix')
 
             has_filts.append(filt)
 

--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -1002,7 +1002,7 @@ class GroupFLT():
         return hdu, fig
 
 
-    def drizzle_grism_models(self, root='grism_model', kernel='square', scale=0.1, pixfrac=1, make_figure=True, fig_xsize=10):
+    def drizzle_grism_models(self, root='grism_model', kernel='square', scale=0.1, pixfrac=1, make_figure=True, fig_xsize=10, write_ctx=False):
         """
         Make model-subtracted drizzled images of each grism / PA
 
@@ -1019,6 +1019,9 @@ class GroupFLT():
 
         pixfrac : float
             Drizzle "pixfrac".
+
+        write_ctx : bool
+            Save context image as well.
 
         """
         try:
@@ -1071,11 +1074,20 @@ class GroupFLT():
                     pixfrac=pixfrac
                 )
 
-                outsci, _, _, _, header, outputwcs = out
+                outsci, _, _, outctx, header, outputwcs = out
                 header['FILTER'] = g
                 header['PA'] = pa
+
+                # Add invidual FLTs to header
+                for i, ix in enumerate(idx):
+                    header[f'FLT{str(i+1).zfill(5)}'] = self.FLTs[ix].grism_file
+
                 pyfits.writeto(outfile, data=outsci, header=header,
                                overwrite=True, output_verify='fix')
+
+                if write_ctx:
+                    pyfits.writeto(outfile.replace('sci', 'ctx'), data=outctx,
+                                header=header, overwrite=True, output_verify='fix')
 
                 # Model-subtracted
                 outfile = '{0}-{1}-{2}_grism_clean.fits'.format(root, g.lower(),

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -8235,7 +8235,7 @@ def drizzle_from_visit(
             # outvar = varnum / outwht
             outvar *= pscale_ratio**-2
 
-        return outsci, outwht, outvar, header, flist, wcs_tab
+        return outsci, outwht, outvar, outctx, header, flist, wcs_tab
 
 
 def drizzle_array_groups(
@@ -8251,6 +8251,7 @@ def drizzle_array_groups(
     calc_wcsmap=False,
     verbose=True,
     data=None,
+    first_uniqid=1,
 ):
     """
     Drizzle array data with associated wcs
@@ -8298,6 +8299,9 @@ def drizzle_array_groups(
         ``data = outsci, outwht, outctx, varnum``, where ``varnum = outvar * outwht``
 
         If not provided, new arrays will be created.
+
+    first_uniqid : int, optional
+        First `uniqid` value to use for the drizzle for contex maps
 
     Returns
     -------
@@ -8399,8 +8403,13 @@ def drizzle_array_groups(
 
     needs_var = (outvar is not None) & (var_list is not None)
 
-    # Do drizzle
+    # Number of input arrays
     N = len(sci_list)
+
+    # Drizzlepac cannot support >31 input images
+    if first_uniqid + N > 31 and verbose:
+        msg = "Warning: Too many input images for context map, will wrap around"
+        log_comment(LOGFILE, msg, verbose=verbose, show_date=True)
     for i in range(N):
         if verbose:
             # log.info('Drizzle array {0}/{1}'.format(i+1, N))
@@ -8425,7 +8434,7 @@ def drizzle_array_groups(
             "cps",
             1,
             wcslin_pscale=wcs_list[i].pscale,
-            uniqid=1,
+            uniqid=((first_uniqid - 1 + i) % 32) + 1,
             pixfrac=pixfrac,
             kernel=kernel,
             fillval="0",


### PR DESCRIPTION
The current grizli implementation of AstroDrizzle was not correctly computing context maps, since it was always setting the ID of the input image to 1, rather than incrementing it. This was fixed in 77412f6. I've also added the ability to optionally output context maps when creating mosaics for the direct and grism images. 