### PR TITLE
Change default blot stepsize to use WCS transform

### DIFF
--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -467,8 +467,10 @@ def blot_nearest_exact(
         If True, print information about the overlap. Default is True.
 
     stepsize : int, optional
-        Step size for interpolation. If set to -1, the function will use a
-        default step size. Default is -1.
+        Step size for interpolation. If set to <=1, the function will use the explicit
+        wcs mapping ``out_wcs.all_pix2world > in_wcs.all_world2pix``.  If > 1,
+        will use
+        ``astrodrizzle.DefaultWCSMapping(out_wcs, in_wcs, nx, ny, stepsize)``.
 
     scale_by_pixel_area : bool
         If True, then scale the output image by the square of the image pixel


### PR DESCRIPTION
The WCS mapping in `grizli.utils.blot_nearest_exact` using `astdrodrizzle.cdriz.DefaultWCSMapping` seems to cause slight errors in the pixel transformations, so set the default ``stepsize=-1`` in various places to fall back to the nominal WCS transformation ``out_wcs.all_pix2world > in_wcs.all_world2pix``.

The most notable place where the issue affects the output was in `grizli.prep.subtract_visit_angle_averages`, where the blotted angle averages didn't line up correctly.