### PR TITLE
Implement `weight_type="jwst_var"` strategy for mosaics with full error propagation

### DIFF
--- a/grizli/aws/aws_drizzler.py
+++ b/grizli/aws/aws_drizzler.py
@@ -782,21 +782,24 @@ def drizzle_images(label='macs0647-jd1', ra=101.9822125, dec=70.24326667, pixsca
         else:
             clean_i = remove
 
-        status = utils.drizzle_from_visit(visits[0],
-                                          h,
-                                          pixfrac=pixfrac, kernel=kernel, 
-                                          clean=clean_i, 
-                                          include_saturated=include_saturated,
-                                          weight_type='median_err',
-                                          skip=skip,
-                                          dryrun=dryrun)
+        status = utils.drizzle_from_visit(
+            visits[0],
+            h,
+            pixfrac=pixfrac,
+            kernel=kernel,
+            clean=clean_i,
+            include_saturated=include_saturated,
+            weight_type='median_err',
+            skip=skip,
+            dryrun=dryrun
+        )
 
         if dryrun:
             filt_dict[filt] = status
             continue
 
         elif status is not None:
-            sci, wht, outh, filt_dict[filt], wcs_tab = status
+            sci, wht, var, outh, filt_dict[filt], wcs_tab = status
 
             if subtract_median:
                 #med = np.median(sci[sci != 0])

--- a/grizli/aws/field_tiles.py
+++ b/grizli/aws/field_tiles.py
@@ -808,13 +808,17 @@ def process_tile(field='cos', tile='01.01', filters=TILE_FILTERS, fetch_existing
             os.system(f'gunzip --force {file}')
             
     if not rgb_only:
-        visit_processor.cutout_mosaic(rootname=root, 
-                              skip_existing=True,
-                              ir_wcs=ir_wcs,
-                              filters=filters, 
-                              pixfrac=pixfrac,
-                              kernel='square', s3output=None, 
-                              gzip_output=False, clean_flt=clean_flt)
+        visit_processor.cutout_mosaic(
+            rootname=root,
+            skip_existing=True,
+            ir_wcs=ir_wcs,
+            filters=filters,
+            pixfrac=pixfrac,
+            kernel='square',
+            s3output=None,
+            gzip_output=False,
+            clean_flt=clean_flt
+        )
     
     files = glob.glob(f'{root}*_dr*fits*')
     if len(files) == 0:
@@ -826,19 +830,29 @@ def process_tile(field='cos', tile='01.01', filters=TILE_FILTERS, fetch_existing
     if make_catalog:
         import golfir.catalog
         
-        golfir.catalog.make_charge_detection(root, ext='ir',
-                        filters=['f160w', 'f140w', 'f125w', 'f110w', 'f105w',
-                                 'f814w', 'f850lp',
-                                 'f277w-clear','f356w-clear','f444w-clear'],
-                                 use_hst_kernel=False,
-                                 subtract_background=True)
-    
-        phot = auto_script.multiband_catalog(field_root=root,
-                       phot_apertures=prep.SEXTRACTOR_PHOT_APERTURES_ARCSEC[:4]) #, **phot_kwargs)
-    
+        golfir.catalog.make_charge_detection(
+            root,
+            ext='ir',
+            filters=[
+                'f160w', 'f140w', 'f125w', 'f110w', 'f105w',
+                'f814w', 'f850lp',
+                'f277w-clear','f356w-clear','f444w-clear'
+            ],
+            use_hst_kernel=False,
+            subtract_background=True
+        )
+
+        phot = auto_script.multiband_catalog(
+            field_root=root,
+            phot_apertures=prep.SEXTRACTOR_PHOT_APERTURES_ARCSEC[:4]
+        ) #, **phot_kwargs)
+
         if len(phot) == 0:
             # Empty catalog
-            db.execute(f"update combined_tiles set status=10 where tile = '{tile}' AND field = '{field}'")
+            db.execute(
+                "update combined_tiles set status=10 "
+                + f"where tile = '{tile}' AND field = '{field}'"
+            )
         
             if cleanup:
 

--- a/grizli/aws/tile_mosaic.py
+++ b/grizli/aws/tile_mosaic.py
@@ -1402,18 +1402,20 @@ def drizzle_tile_subregion(tile=2530, subx=522, suby=461, filter='F160W', s3outp
         
     if s3output is None:
         s3output = f's3://grizli-mosaic-tiles/Tiles/{tile}/'
-    
+
     try:
-        visit_processor.cutout_mosaic(rootname=root,
-                                  product='{rootname}.{f}',
-                                  ir_wcs=ir_wcs,
-                                  res=exp, 
-                                  s3output=s3output, 
-                                  make_figure=make_figure,
-                                  skip_existing=skip_existing,
-                                  gzip_output=gzip_output,
-                                  **kwargs)
-    
+        visit_processor.cutout_mosaic(
+            rootname=root,
+            product='{rootname}.{f}',
+            ir_wcs=ir_wcs,
+            res=exp,
+            s3output=s3output,
+            make_figure=make_figure,
+            skip_existing=skip_existing,
+            gzip_output=gzip_output,
+            **kwargs
+        )
+
         # Update subtile status
         db.execute(f"""UPDATE mosaic_tiles_exposures t
               SET in_mosaic = 1
@@ -1422,6 +1424,7 @@ def drizzle_tile_subregion(tile=2530, subx=522, suby=461, filter='F160W', s3outp
               AND w.filter='{filter}' AND tile={tile}
               AND subx={subx} AND suby={suby}
                """)
+
     except TypeError:
         db.execute(f"""UPDATE mosaic_tiles_exposures t
               SET in_mosaic = 8
@@ -1430,7 +1433,7 @@ def drizzle_tile_subregion(tile=2530, subx=522, suby=461, filter='F160W', s3outp
               AND w.filter='{filter}' AND tile={tile}
               AND subx={subx} AND suby={suby}
                """)
-        
+
     status = '{root}.{f}'
     return status
 

--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -266,6 +266,7 @@ multiband_catalog_args:
     use_bkg_err: False
     aper_segmask: True
     rescale_weight: False
+    prefer_var_image: True
 
 # Stop after image preparation even if grism exists    
 only_preprocess: False 

--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -1044,7 +1044,11 @@ class GroupFLT():
                 clean_list = [self.FLTs[i].grism['SCI']-self.FLTs[i].model
                                  for i in idx]
 
-                wht_list = [(self.FLTs[i].grism['DQ'] == 0)/self.FLTs[i].grism['ERR']**2 for i in idx]
+                wht_list = [
+                    (self.FLTs[i].grism['DQ'] == 0) / self.FLTs[i].grism['ERR']**2
+                    for i in idx
+                ]
+
                 for i in range(N):
                     mask = ~np.isfinite(wht_list[i])
                     wht_list[i][mask] = 0
@@ -1058,11 +1062,16 @@ class GroupFLT():
                 outfile = '{0}-{1}-{2}_grism_sci.fits'.format(root, g.lower(),
                                                             pa)
                 print(outfile)
-                out = drizzle_array_groups(sci_list, wht_list, wcs_list,
-                                           scale=scale, kernel=kernel,
-                                           pixfrac=pixfrac)
+                out = drizzle_array_groups(
+                    sci_list,
+                    wht_list,
+                    wcs_list,
+                    scale=scale,
+                    kernel=kernel,
+                    pixfrac=pixfrac
+                )
 
-                outsci, _, _, header, outputwcs = out
+                outsci, _, _, _, header, outputwcs = out
                 header['FILTER'] = g
                 header['PA'] = pa
                 pyfits.writeto(outfile, data=outsci, header=header,
@@ -1072,11 +1081,16 @@ class GroupFLT():
                 outfile = '{0}-{1}-{2}_grism_clean.fits'.format(root, g.lower(),
                                                               pa)
                 print(outfile)
-                out = drizzle_array_groups(clean_list, wht_list, wcs_list,
-                                           scale=scale, kernel=kernel,
-                                           pixfrac=pixfrac)
+                out = drizzle_array_groups(
+                    clean_list,
+                    wht_list,
+                    wcs_list,
+                    scale=scale,
+                    kernel=kernel,
+                    pixfrac=pixfrac
+                )
 
-                outsci, _, _, header, outputwcs = out
+                outsci, _, _, _, header, outputwcs = out
                 header['FILTER'] = g
                 header['PA'] = pa
                 pyfits.writeto(outfile, data=outsci, header=header,
@@ -3396,7 +3410,16 @@ class MultiBeam(GroupFitter):
         wht_list = [np.isfinite(beam.beam.seg)*1. for beam in self.beams]
         wcs_list = [beam.direct.wcs for beam in self.beams]
 
-        out = utils.drizzle_array_groups(sci_list, wht_list, wcs_list, outputwcs=wcs, scale=0.1, kernel=kernel, pixfrac=pixfrac, verbose=verbose)
+        out = utils.drizzle_array_groups(
+            sci_list,
+            wht_list,
+            wcs_list,
+            outputwcs=wcs,
+            scale=0.1,
+            kernel=kernel,
+            pixfrac=pixfrac,
+            verbose=verbose
+        )
         drizzled_segm = (out[0] > 0)*id
 
         return drizzled_segm


### PR DESCRIPTION
For a weighted sum of noisy data $y = \sum_i(w_i x_i)  / \sum_i(w_i)$, the "optimal" weight that produces the minimum $\mathrm{Var}(y)$ is $w_i = 1 / \sigma_i^2$, i.e, weighting by the inverse variance of $x_i$.  For general $w_i$, 

  $\mathrm{Var}(y) = \sum_i (w_i^2 \sigma_i^2) / (\sum_i w_i)^2$. (**Eq. 1**)

This reduces to $\mathrm{Var}(y) = 1 / \sum_i w_i$ for the optimal weights $w_i = 1/\sigma_i^2$.

The "drizzle" co-addition of images is essentially the linear sum above after projecting an input pixel grid to the desired output pixel grid, accounting for camera distortions, pixel scale, etc.  The noise-optimal weights for drizzle resampling image $I$ are $W = 1 / V$, where $V$ is the variance image created from the propagated uncertainties of the noise model for image $I$, including, e.g., detector read noise and the Poisson term from the recorded photoelectrons.  However, with the somewhat undersampled space telescope images from HST and JWST, including the Poisson component tends to corrupt the *spatial* morphology of compact, high S/N sources where the Poisson term dominates.

In relatively recent updates to ``grizli``, we included implementation of a number of weighting schemes using different combinations of the exposure noise model.  The default used for the ``v7`` mosaics of the DAWN JWST Archive use ``weight_type="jwst"``, where the weights for image $i$ are calculated with

$W_i^{-1} = V_{i,\mathrm{RN}} + \mathrm{Median}(V_{i,\mathrm{Poisson}})$.  (**Eq. 2**)

This therefore includes relative weighting for, e.g., both varying exposure times and background levels within the list of exposures combined to a final mosaic, but recovering the full variance thus required calculating the Poisson term for detected sources using the science and exposure time maps.

Here we implement a new scheme ``weight_type="jwst_var"`` that produces the full variance map of the drizzle product at runtime using a combination of **Eqs. 1** and **2**:

  $V_\mathrm{drz} = \sum_i (W_i^2 V_i^2) / (\sum_i W_i)^2$,

where $V_i = V_{i,\mathrm{RN}} + V_{i,\mathrm{Poisson}}$ includes the full Poisson map.

Running
```python
grizli.aws.visit_processor.cutout_mosaic(..., weight_type="jwst_var")
```
creates an additional image product ``..._drc_var.fits`` from this combination.  The file ``..._drc_wht.fits`` is the inverse variance map as before *without* the Poisson term for discrete sources.