### PR TITLE
Fixed Bug in CTX implementation. 

### DIFF
--- a/grizli/aws/visit_processor.py
+++ b/grizli/aws/visit_processor.py
@@ -3012,7 +3012,7 @@ def make_mosaic(jname='', ds9=None, skip_existing=True, ir_scale=0.1, half_optic
             **kwargs
         )
                              
-        outsci, outwht, outvar,outctx, header, flist, wcs_tab = _
+        outsci, outwht, outvar, outctx, header, flist, wcs_tab = _
     
         pyfits.writeto(
             groups[f]['product']+'_drz_sci.fits',

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -3904,7 +3904,7 @@ def subtract_visit_angle_averages(visit, threshold=1.8, detection_background=Tru
             weight_type=weight_type,
         )
 
-        data, wht, ctx, var, drz_h, files, info = drz
+        data, wht, var, ctx, drz_h, files, info = drz
 
         drz_h['PA_APER'] = pa_aper, 'PA_APER used for reference'
         drz_h['BKGANGLE'] = (','.join([f'{a:.1f}' for a in angles]), 

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -8214,7 +8214,7 @@ def drizzle_from_visit(
                 data=None,
             )
 
-            outsci, outwht, outctx, outvar, header, xoutwcs = res
+            outsci, outwht, outvar, outctx, header, xoutwcs = res
 
             header["EXPTIME"] = flt[0].header["EXPTIME"]
             header["NDRIZIM"] = 1
@@ -8258,7 +8258,7 @@ def drizzle_from_visit(
                 data=data,
             )
 
-            outsci, outwht, outctx, outvar = res[:4]
+            outsci, outwht, outvar, outctx = res[:4]
             header["EXPTIME"] += flt[0].header["EXPTIME"]
             header["NDRIZIM"] += 1
 
@@ -8541,7 +8541,7 @@ def drizzle_array_groups(
         # extra factor of Sum(w_i) for var = Sum(w_i**2 * var_i) / Sum(w_i)**2
         outvar /= outwht
 
-    return outsci, outwht, outctx, outvar, header, outputwcs
+    return outsci, outwht, outvar, outctx, header, outputwcs
 
 
 class WCSMapAll:


### PR DESCRIPTION
#239 Introduced a bug (sorry!) where I was not properly handling the order of returning the context map and the new variance map between `drizzle_array_groups` and `drizzle_from_visit`. Now it is consistent everywhere. 