### PR TITLE
Add Multi-threading Potential for Contamination

### DIFF
--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -626,21 +626,33 @@ class GroupFLT():
         for flt_i in self.FLTs:
             if hasattr(flt_i, 'conf'):
                 delattr(flt_i, 'conf')
-                
-        pool = mp.Pool(processes=cpu_count)
-        jobs = [pool.apply_async(_compute_model, 
-                                 (i, self.FLTs[i], fit_info, 
-                                  is_cgs, store, model_kwargs))
-                for i in range(self.N)]
 
-        pool.close()
-        pool.join()
+        if cpu_count > 1:
+            with mp.Pool(processes=cpu_count) as pool:
+                jobs = pool.starmap_async(
+                    _compute_model, 
+                    [
+                        (
+                            i, 
+                            self.FLTs[i], 
+                            fit_info, 
+                            is_cgs, store,
+                            model_kwargs
+                        ) 
+                        for i in range(self.N)
+                    ]
+                )
+                results = jobs.get()
+            for res in results:
+                i, model, dispersers = res
+                self.FLTs[i].object_dispersers = dispersers
+                self.FLTs[i].model = model
+        else:
+            for i in range(self.N):
+                _, model, dispersers = _compute_model(i, self.FLTs[i], fit_info, is_cgs, store, model_kwargs)
+                self.FLTs[i].object_dispersers = dispersers
+                self.FLTs[i].model = model
 
-        for res in jobs:
-            i, model, dispersers = res.get(timeout=1)
-            self.FLTs[i].object_dispersers = dispersers
-            self.FLTs[i].model = model
-        
         # Reload conf
         for flt_i in self.FLTs:
             if not hasattr(flt_i, 'conf'):
@@ -736,7 +748,7 @@ class GroupFLT():
 
     def refine_list(self, ids=[], mags=[], poly_order=3, mag_limits=[16, 24],
                     max_coeff=5, ds9=None, verbose=True, fcontam=0.5,
-                    wave=np.linspace(0.2, 2.5e4, 100)):
+                    wave=np.linspace(0.2, 2.5e4, 100), thread_count=1):
         """Refine contamination model for list of objects.  Loops over `refine`.
 
         Parameters
@@ -771,6 +783,9 @@ class GroupFLT():
         wave : `~numpy.array`
             Wavelength array for the polynomial fit.
 
+        thread_count : int
+            Number of Threads to use for parallel processing (multithreaded)
+
         Returns
         -------
         Updates `self.model` in place.
@@ -789,11 +804,150 @@ class GroupFLT():
         #wave = np.linspace(0.2,5.4e4,100)
         poly_templates = utils.polynomial_templates(wave, order=poly_order, line=False)
 
-        for id, mag in zip(ids, mags):
-            self.refine(id, mag=mag, poly_order=poly_order,
-                        max_coeff=max_coeff, size=30, ds9=ds9,
-                        verbose=verbose, fcontam=fcontam,
-                        templates=poly_templates)
+        # Multi-threading
+        if thread_count > 1:
+
+            # Create rtree and DAG
+            from rtree import index
+            import networkx as nx
+            from networkx import DiGraph
+            rtree_idx = index.Index()
+            dag = DiGraph()
+
+            # Iterate over sources from bright to faint
+            msg = 'Creating DAG of Refinements'
+            utils.log_comment(utils.LOGFILE, msg, verbose=True)
+            import tqdm
+            for id in tqdm.tqdm(ids):
+
+                # Get beams
+                beams = self.get_beams(id, size=30, min_overlap=0.1,
+                                       get_slice_header=False, min_mask=0.01,
+                                       min_sens=0.01, mask_resid=True)
+
+                bounds = []
+                for beam in beams:
+
+                    # Compute beam boundaries
+                    slx,sly = beam.beam.slx_parent, beam.beam.sly_parent
+                    bound = (slx.start, sly.start, slx.stop, sly.stop)
+                    bounds.append(bound)
+
+                    # Check if there are any overlaps in RTree
+                    overlap_ids = list(rtree_idx.intersection(bound))
+
+                    # Current object must be fainter, so direction is from bright to faint
+                    for overlap_id in overlap_ids:
+                        dag.add_edge(overlap_id,id)
+
+                # Add current object to RTree
+                for bound in bounds:
+                    rtree_idx.insert(id, bound)
+            
+            # Create topological layers
+            topological_order = list(nx.topological_sort(dag))
+            
+            # Initialize layers dictionary
+            layers = {}
+            
+            # Initialize the first layer
+            current_layer = 0
+            layers[current_layer] = []
+            
+            # Initialize a set to keep track of visited nodes
+            visited = set()
+            
+            # Iterate through the topological order
+            for node in topological_order:
+                # If the node has no incoming edges, it starts a new layer
+                if dag.in_degree(node) == 0:
+                    layers[current_layer].append(node)
+                else:
+                    # Check if this node belongs to a previous layer
+                    for predecessor in dag.predecessors(node):
+                        if predecessor in visited:
+                            layers[current_layer].append(node)
+                            break
+                    else:
+                        # If none of the predecessors are in the current layer, increment the layer
+                        current_layer += 1
+                        layers[current_layer] = [node]
+
+                # Mark the node as visited
+                visited.add(node)
+
+            # Print Graph summary
+            msg = ''
+            utils.log_comment(utils.LOGFILE, msg, verbose=True)
+
+            # Create topological layers
+            layers = []
+            node_layers = {}
+
+            # Iterate through the topological order
+            msg = 'Creating Topological Layers'
+            utils.log_comment(utils.LOGFILE, msg, verbose=True)
+            for node in nx.topological_sort(dag):
+                # If the node has no incoming edges, it starts a new layer
+                if dag.in_degree(node) == 0:
+                    # Top Layer nodes in layer 0
+                    node_layers[node] = 0
+                else:
+                    node_layers[node] = (
+                        max(node_layers[pred] for pred in dag.predecessors(node)) + 1
+                    )
+
+                # Ensure all necessary layers exist
+                while len(layers) <= node_layers[node]:
+                    layers.append([])
+
+                # Add node to layer
+                layers[node_layers[node]].append(node)
+
+            # # Record layer summary
+            # lens = [len(l) for l in layers]
+            # msg = f'{len(layers)} found, with a min/max size of {min(lens)}/{max(lens)}'
+            # utils.log_comment(utils.LOGFILE, msg, verbose=True)
+
+            # Iterate over layers and multi-thread
+            for i,layer in enumerate(layers):
+
+                msg = f'Refining layer {i} with size {len(layer)} (multi-threaded)'
+                utils.log_comment(utils.LOGFILE, msg, verbose=True)
+                
+                # Get magnitudes
+                layer_mags = np.array([mags[id == ids] for id in layer]).flatten()
+
+                # Arguements
+                args = [
+                    dict(
+                        id = id, 
+                        mag = mag, 
+                        poly_order = poly_order,
+                        max_coeff = max_coeff,
+                        size = 30,
+                        ds9 = ds9,
+                        verbose = verbose,
+                        fcontam = fcontam,
+                        templates = poly_templates
+                    )
+                    for id,mag in zip(layer,layer_mags)
+                ]
+
+                # Multithread Layer
+                from concurrent.futures import ThreadPoolExecutor
+                with ThreadPoolExecutor(max_workers=thread_count) as executor:
+                    executor.map(self.refine_wrapper, args)
+
+        else:
+            for id, mag in zip(ids, mags):
+                self.refine(id, mag=mag, poly_order=poly_order,
+                            max_coeff=max_coeff, size=30, ds9=ds9,
+                            verbose=verbose, fcontam=fcontam,
+                            templates=poly_templates)
+
+    def refine_wrapper(self,args):
+        return self.refine(**args)
 
     def refine(self, id, mag=-99, poly_order=3, size=30, ds9=None, verbose=True, max_coeff=2.5, fcontam=0.5, templates=None):
         """Fit polynomial to extracted spectrum of single object to use for contamination model.

--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -809,8 +809,7 @@ class GroupFLT():
 
             # Create rtree and DAG
             from rtree import index
-            import networkx as nx
-            from networkx import DiGraph
+            from networkx import DiGraph, topological_sort
             rtree_idx = index.Index()
             dag = DiGraph()
 
@@ -843,41 +842,9 @@ class GroupFLT():
                 # Add current object to RTree
                 for bound in bounds:
                     rtree_idx.insert(id, bound)
-            
-            # Create topological layers
-            topological_order = list(nx.topological_sort(dag))
-            
-            # Initialize layers dictionary
-            layers = {}
-            
-            # Initialize the first layer
-            current_layer = 0
-            layers[current_layer] = []
-            
-            # Initialize a set to keep track of visited nodes
-            visited = set()
-            
-            # Iterate through the topological order
-            for node in topological_order:
-                # If the node has no incoming edges, it starts a new layer
-                if dag.in_degree(node) == 0:
-                    layers[current_layer].append(node)
-                else:
-                    # Check if this node belongs to a previous layer
-                    for predecessor in dag.predecessors(node):
-                        if predecessor in visited:
-                            layers[current_layer].append(node)
-                            break
-                    else:
-                        # If none of the predecessors are in the current layer, increment the layer
-                        current_layer += 1
-                        layers[current_layer] = [node]
-
-                # Mark the node as visited
-                visited.add(node)
 
             # Print Graph summary
-            msg = ''
+            msg = f'{len(dag)} nodes and {dag.number_of_edges()} edges found'
             utils.log_comment(utils.LOGFILE, msg, verbose=True)
 
             # Create topological layers
@@ -887,7 +854,7 @@ class GroupFLT():
             # Iterate through the topological order
             msg = 'Creating Topological Layers'
             utils.log_comment(utils.LOGFILE, msg, verbose=True)
-            for node in nx.topological_sort(dag):
+            for node in topological_sort(dag):
                 # If the node has no incoming edges, it starts a new layer
                 if dag.in_degree(node) == 0:
                     # Top Layer nodes in layer 0
@@ -903,11 +870,6 @@ class GroupFLT():
 
                 # Add node to layer
                 layers[node_layers[node]].append(node)
-
-            # # Record layer summary
-            # lens = [len(l) for l in layers]
-            # msg = f'{len(layers)} found, with a min/max size of {min(lens)}/{max(lens)}'
-            # utils.log_comment(utils.LOGFILE, msg, verbose=True)
 
             # Iterate over layers and multi-thread
             for i,layer in enumerate(layers):

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -3353,7 +3353,7 @@ def load_GroupFLT(field_root='j142724+334246', PREP_PATH='../Prep', force_ref=No
         return [grp]
 
 
-def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='../Extractions', ds9=None, refine_niter=3, gris_ref_filters=GRIS_REF_FILTERS, force_ref=None, files=None, split_by_grism=True, refine_poly_order=1, refine_fcontam=0.5, cpu_count=0, mask_mosaic_edges=False, prelim_mag_limit=25, refine_mag_limits=[18, 24], init_coeffs=[1.1, -0.5], grisms_to_process=None, pad=(64, 256), model_kwargs={'compute_size': True}, sep_background_kwargs=None, subtract_median_filter=False, median_filter_size=71, median_filter_central=10, second_pass_filtering=False, box_filter_sn=3, box_filter_width=3, median_mask_sn_threshold=None, median_mask_dilate=8, prelim_model_for_median=False, use_jwst_crds=False):
+def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='../Extractions', ds9=None, refine_niter=3, gris_ref_filters=GRIS_REF_FILTERS, force_ref=None, files=None, split_by_grism=True, refine_poly_order=1, refine_fcontam=0.5, cpu_count=0, mask_mosaic_edges=False, prelim_mag_limit=25, refine_mag_limits=[18, 24], init_coeffs=[1.1, -0.5], grisms_to_process=None, pad=(64, 256), model_kwargs={'compute_size': True}, sep_background_kwargs=None, subtract_median_filter=False, median_filter_size=71, median_filter_central=10, second_pass_filtering=False, box_filter_sn=3, box_filter_width=3, median_mask_sn_threshold=None, median_mask_dilate=8, prelim_model_for_median=False, use_jwst_crds=False, refine_threads=1):
     """
     Contamination model pipeline for grism exposures
     
@@ -3453,6 +3453,9 @@ def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='.
     
     use_jwst_crds : bool
         Use CRDS `specwcs` files for JWST grism trace configuration
+
+    refine_threads : int
+        Number of threads to use for contamination modelling, only use if GIL is disabled. 
     
     Returns
     -------
@@ -3609,7 +3612,8 @@ def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='.
                                 mag_limits=refine_mag_limits,
                                 max_coeff=5, ds9=ds9, verbose=True,
                                 fcontam=refine_i,
-                                wave=np.linspace(*grp.polyx[:2], 100)*1.e4)
+                                wave=np.linspace(*grp.polyx[:2], 100)*1.e4,
+                                thread_count=refine_threads)
         
             # Do background again
             if sep_background_kwargs is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ install_requires =
     stwcs
     tqdm
     tristars
+    rtree
 packages = find:
 include_package_data = True
 


### PR DESCRIPTION
This is a longer-term update to speed up refining the contamination model. As Python 3.13 now has testing versions with the GIL disabled, we can take advantage of multi-threading to compute the refined models. The current `refine_list` algorithm goes down in source magnitude and models the sources as any fainter source needs the model of the brighter source in its neighbourhood to be processed first. To address this, I have implemented the following:

1) Build a DAG refinement dependency:
1.1) In order of increasing magnitude (brightest first), placing each source into an R-Tree
1.2) If a source overlaps with an existing source, adding an edge from the old source to the new source (guaranteed to be from brighter to fainter). 
2) Assign each node to a layer based on the maximum layer of all parent nodes plus one, with nodes of in-degree 0 assigned to layer 0. 
3) Multi-thread within each layer. 

The behavior is controlled by the `refine_threads` argument to `grism_prep`. It may be good to create helper functions somewhere else for the added code, maybe `utils`? I'm open to suggestions. Currently this code offers no speed improvement, but will become useful when grizli and its dependencies become compatible with Python 3.13 with the GIL disabled. 

Another quick change I made is to only use multiprocessing if the cpu_count is greater than 1 for computing the full model. 