### PR TITLE
Use environ context for tweak align

### DIFF
--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -8036,6 +8036,8 @@ def drizzle_from_visit(
         if scale_photom:
             # Scale to a particular JWST context and update header keywords
             # like PHOTFLAM, PHOTFNU
+            if 'CRDS_CONTEXT' in os.environ:
+                context = os.environ['CRDS_CONTEXT']
             _scale_jwst_photom = jwst_crds_photom_scale(
                 flt,
                 update=True,


### PR DESCRIPTION
During tweak align, grizli uses a hard-coded CRDS context to apply a photom correction. However, this is quite an old context, and if the CRDS folder is write only (as it is in shared environments), it will cause a failure. As this doesn't affect the final output (only used to compute the tweak shifts) I have added in a check to use the environment context value if it exists. 