### PR TITLE
Adapt to new stpipe standard

### DIFF
--- a/grizli/jwst_utils.py
+++ b/grizli/jwst_utils.py
@@ -585,7 +585,7 @@ def img_with_flat(
     if not skip:
 
         flat_step = FlatFieldStep()
-        _flatfile = flat_step.get_reference_file(img, "flat")
+        _flatfile = flat_step.get_reference_file(input, "flat")
         utils.log_comment(
             utils.LOGFILE,
             f"jwst.flatfield.FlatFieldStep: {_flatfile}",
@@ -609,7 +609,7 @@ def img_with_flat(
             photom_step = PhotomStep()
             with_phot = photom_step.process(with_flat)
             output = with_phot
-            _photfile = photom_step.get_reference_file(img, "photom")
+            _photfile = photom_step.get_reference_file(input, "photom")
             utils.log_comment(
                 utils.LOGFILE,
                 f"jwst.flatfield.PhotomStep: {_photfile}",
@@ -795,7 +795,7 @@ def img_with_wcs(
 
     # AssignWcs to pupulate img.meta.wcsinfo
     step = AssignWcsStep()
-    _distor_file = step.get_reference_file(img, "distortion")
+    _distor_file = step.get_reference_file(input, "distortion")
     utils.log_comment(
         utils.LOGFILE,
         f"jwst.assign_wcs.AssignWcsStep: {_distor_file}",
@@ -1614,7 +1614,7 @@ def initialize_jwst_image(
             img[0].header[k] = targ
 
     # Get flat field ref file
-    _flatfile = FlatFieldStep().get_reference_file(img, "flat")
+    _flatfile = FlatFieldStep().get_reference_file(filename, "flat")
     img[0].header["PFLTFILE"] = os.path.basename(_flatfile)
     msg = f"PFLTFILE = {_flatfile}"
     utils.log_comment(utils.LOGFILE, msg, verbose=verbose)


### PR DESCRIPTION
Fixes an issue where in the new versions of stpipe, you can't pass an HDUList, so we can pass filenames instead with very little code change. 