### PR TITLE
Add option for computing the visit background with a segmentation mask

### DIFF
--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -127,6 +127,13 @@ visit_prep_args: &prep_args
         fw: 3
         pixel_scale: 0.10
         get_median: False
+    bkg_detection_threshold: null
+    imaging_masked_bkg_params:
+        bh: 32
+        bw: 32
+        fh: 5
+        fw: 5
+        pixel_scale: 0.10
     run_separate_chip_sky: True
     fix_stars: False
     reference_catalogs: [LS_DR10, LS_DR9, PS1, DES, DSC, SDSS, GAIA, WISE]

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -2659,9 +2659,9 @@ def get_line_wavelengths():
     line_ratios["CIII-1906"] = [1.0]
     line_wavelengths["CIII-1908"] = [1908.734]
     line_ratios["CIII-1908"] = [1.0]
-    line_wavelengths["CI-9580"] = [9850.26]  # leave typo for back compatibility
+    line_wavelengths["CI-9580"] = [9852.96]  # leave typo for back compatibility
     line_ratios["CI-9580"] = [1.0]
-    line_wavelengths["CI-9850"] = [9850.26]
+    line_wavelengths["CI-9850"] = [9852.96]
     line_ratios["CI-9850"] = [1.0]
 
     # Sodium D I lines from Davies 2023


### PR DESCRIPTION
The default behavior of the `grizli.prep` preprocessing workflow included an option to estimate a 2D background from the mosaic combined from the exposures in the association and blot that back to the frame of the individual exposures.  The default parameters used a conservative median filter size with no additional source masking.

With this update, with `grizli.prep.blot_background(..., bkg_params={...}, detection_threshold=detection_threshold, masked_bkg_params={...}`, the algorithm will first generate a segmentation mask using the background parameters in `bkg_params` and then compute a masked background with `masked_bkg_params`.

The parameters
```python
bkg_params = {"bw": 256, "bh": 256, "fw": 3, "fh": 3, "pixel_scale": 0.1}

detection_threshold = 1.1
masked_bkg_params = {"bw": 32, "bh": 32, "fw": 5, "fh": 5, "pixel_scale": 0.1}
```
would result in a more aggressive background filtering including the source masking.  

The previous default behavior with no source masking is achieved with `detection_threshold=None`.

**Note:** These parameters are passed at the pipeline level in `grizli.aws.visit_processor` and `grizli.prep.process_direct_grism_visit` with the names `imaging_bkg_params`, `bkg_detection_threshold`, and `imaging_masked_bkg_params`.
