### PR TITLE
Update utils.py

### DIFF
--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -7866,6 +7866,8 @@ def drizzle_from_visit(
 
             if (extra_wfc3ir_badpix) & (_inst in ['NIRCAM','NIRISS']):
                 bpfiles = [os.path.join(os.path.dirname(__file__),
+                           f'data/nrc_badpix_10162025_{_det}.fits.gz')]
+                bpfiles += [os.path.join(os.path.dirname(__file__),
                            f'data/nrc_badpix_240627_{_det}.fits.gz')]
                 bpfiles += [os.path.join(os.path.dirname(__file__),
                            f'data/nrc_badpix_240112_{_det}.fits.gz')]


### PR DESCRIPTION
Update NIRCAM LW bad pixel mask to include:
1. DO_NOT_USE pixels from CRDS_CONTEXT = jwst_1431.pmap
2. Outlier Pixels found in LW Imaging from the July-August 2025 MINERVA-UDS program imaging (PID: 7814), created by a source-masked median stack of all LW bands, where ouliers are defined as pixels in the median stack which are outside (-12 sigmaNMAD, +15 sigmaNMAD) 

An additional ~0.03% of the LW detector pixels are flagged in these new bpix masks, on top of the ~1.7% which were already flagged in the previous bad pixel masks. 