### PR TITLE
Roll back to force drizzlepac 3.6.2

### DIFF
--- a/grizli/jwst_utils.py
+++ b/grizli/jwst_utils.py
@@ -4774,7 +4774,8 @@ def flag_nirspec_hot_pixels(
 
     bits = get_jwst_dq_bit(jwst_dq_flags)
 
-    mask = (rate["DQ"].data & bits > 0) | (rate["ERR"].data <= 0)
+    mask = (rate["DQ"].data.astype(np.int32) & bits > 0)
+    mask |= (rate["ERR"].data <= 0)
     mask |= (rate["SCI"].data < -3 * rate["ERR"].data) | (
         ~np.isfinite(rate["SCI"].data)
     )
@@ -4932,7 +4933,8 @@ def flag_nircam_hot_pixels(
 
     bits = get_jwst_dq_bit(jwst_dq_flags)
 
-    mask = (rate["DQ"].data & bits > 0) | (rate["ERR"].data <= 0)
+    mask = (rate["DQ"].data.astype(np.int32) & bits > 0)
+    mask |= (rate["ERR"].data <= 0)
     mask |= (rate["SCI"].data < -3 * rate["ERR"].data) | (
         ~np.isfinite(rate["SCI"].data)
     )
@@ -4984,7 +4986,7 @@ def flag_nircam_hot_pixels(
     else:
         plusses = (dplus > plus_sn_min) & (dcorner < corner_sn_max)
 
-    plusses &= (rate["DQ"].data & bits > 0) | hot
+    plusses &= (rate["DQ"].data.astype(np.int32) & bits > 0) | hot
 
     plus_mask = nd.binary_dilation(plusses, structure=PLUS_FOOTPRINT)
 

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -544,7 +544,7 @@ def apply_persistence_mask(
     flt[0].header["PERSGROW"] = (grow_mask, "Perristence mask dilation grow_mask")
 
     if reset:
-        flt["DQ"].data -= flt["DQ"].data & dq_value
+        flt["DQ"].data -= flt["DQ"].data.astype(np.int32) & dq_value
 
     if NPERS > 0:
         flt["DQ"].data[pers_mask > 0] |= dq_value
@@ -1903,12 +1903,14 @@ def make_SEP_catalog_from_arrays(
     uJy_to_dn = 1 / (3631 * 1e6 * 10 ** (-0.4 * ZP))
 
     if sci.dtype != np.float32:
-        sci_data = sci.byteswap().newbyteorder()
+        # sci_data = sci.byteswap().newbyteorder()
+        sci_data = sci.astype(np.float32)
     else:
         sci_data = sci
 
     if err.dtype != np.float32:
-        err_data = err.byteswap().newbyteorder()
+        # err_data = err.byteswap().newbyteorder()
+        err_data = err.astype(np.float32)
     else:
         err_data = err
 
@@ -2300,7 +2302,8 @@ def make_SEP_catalog(
             WEIGHT_TYPE = "VARIANCE"
 
     drz_im = pyfits.open(drz_file)
-    data = drz_im[0].data.byteswap().newbyteorder()
+    # data = drz_im[0].data.byteswap().newbyteorder()
+    data = drz_im[0].data.astype(np.float32)
 
     logstr = f"make_SEP_catalog: {drz_file} weight={weight_file} ({WEIGHT_TYPE})"
     utils.log_comment(utils.LOGFILE, logstr, verbose=verbose, show_date=True)
@@ -2337,7 +2340,8 @@ def make_SEP_catalog(
     need_err = (not use_bkg_err) | (not get_background)
     if (weight_file is not None) & need_err:
         wht_im = pyfits.open(weight_file)
-        wht_data = wht_im[0].data.byteswap().newbyteorder()
+        # wht_data = wht_im[0].data.byteswap().newbyteorder()
+        wht_data = wht_im[0].data.astype(np.float32)
 
         if WEIGHT_TYPE == "VARIANCE":
             err_data = np.sqrt(wht_data)
@@ -2982,7 +2986,8 @@ def compute_SEP_auto_params(
     segb = segmap
     if segmap is not None:
         if segmap.dtype == np.dtype(">i4"):
-            segb = segmap.byteswap().newbyteorder()
+            # segb = segmap.byteswap().newbyteorder()
+            segb = segmap.astype(np.int32)
 
     if "a_image" in tab.colnames:
         x, y = tab["x_image"] - 1, tab["y_image"] - 1

--- a/grizli/utils.py
+++ b/grizli/utils.py
@@ -8232,7 +8232,7 @@ def drizzle_from_visit(
                     if jwst_dq_flags is not None:
                         bad_bits |= get_jwst_dq_bit(jwst_dq_flags, verbose=verbose)
 
-                    dq = flt[("DQ", ext)].data & bad_bits
+                    dq = flt[("DQ", ext)].data.astype(np.int32) & bad_bits
                     dq |= bpdata.astype(dq.dtype)
 
                     # Clipping threshold for BKG extensions, global at top

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>68.1", "setuptools_scm[toml]>=6.2", "wheel",
+requires = ["setuptools==67.8.0", "setuptools_scm[toml]>=6.2", "wheel",
             "oldest-supported-numpy", "cython"]
 build-backend = "setuptools.build_meta"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,11 +55,11 @@ docs =
     sphinx
     sphinx-astropy
 jwst =
-    jwst<=1.19
+    jwst<1.17
     pysiaf
     grismconf==1.32
     numba
-    drizzlepac
+    drizzlepac<3.7.0
     snowblind>=0.2.1
     crds<13.0
 aws =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     scikit-learn
     scipy>=1.6
     sep
-    setuptools
+    setuptools==67.8.0
     shapely
     sregion>=1.2.2
     stwcs

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     matplotlib
     numpy>=1.4
     numba
-    photutils<1.19
+    photutils<1.13
     regions
     scikit-image>=0.20.0
     scikit-learn

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     matplotlib
     numpy>=1.4
     numba
-    photutils
+    photutils<1.19
     regions
     scikit-image>=0.20.0
     scikit-learn


### PR DESCRIPTION
For some reason associations processed `drizzlepac>=3.7.0` are full of masked bad pixels, and resolving this will require more investigation.  This update rolls back to `drizzlepac==3.6.2` and an older version of `jwst<1.17` that is known to work and also remains consistent with everything processed thus far in DJA.