### PR TITLE
NIRISS WFSS Background Reference Flag Update

### DIFF
--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -7819,7 +7819,7 @@ def get_jwst_wfssbkg_file(
     from jwst.wfss_contam import WfssContamStep
     from jwst.flatfield import FlatFieldStep
 
-    bkg_file = WfssContamStep().get_reference_file(file, "wfssbkg")
+    bkg_file = WfssContamStep().get_reference_file(file, "bkg")
 
     # Not a FITS file?  e.g., N/A for imaging exposures
     if ("fits" not in bkg_file) and (not ignoreNA):


### PR DESCRIPTION
JWST pipeline / references changed behaviour for NIRISS WFSS Background files.
They are now referenced as bkg, not wfssbkg. 
Passing wfssbkg will result in an error. 