### PR TITLE
Check if 1/f correction was applied using the STScI JWST pipeline.

### DIFF
--- a/grizli/jwst_utils.py
+++ b/grizli/jwst_utils.py
@@ -1445,7 +1445,10 @@ def exposure_oneoverf_correction(
 
         return None, 0
 
-    if ("ONEFEXP" in im[0].header) and im[0].header["ONEFEXP"] and (not force_oneoverf):
+    if (
+        (("ONEFEXP" in im[0].header) and im[0].header["ONEFEXP"])
+        or (("S_CLNFNS" in im[0].header) and (im[0].header["S_CLNFNS"] == "COMPLETE"))
+    ) and (not force_oneoverf):
         im.close()
 
         msg = "exposure_oneoverf_correction: Skip, already corrected"


### PR DESCRIPTION
Check if the 1/f correction was already applied using the JWST pipeline ([`CleanFlickerNoiseStep`](https://jwst-pipeline.readthedocs.io/en/stable/api/jwst.clean_flicker_noise.clean_flicker_noise_step.CleanFlickerNoiseStep.html#jwst.clean_flicker_noise.clean_flicker_noise_step.CleanFlickerNoiseStep)) via the header keywords. As `exposure_oneoverf_correction()` is called from `jwst_utils.set_jwst_to_hst_keywords()`, at present there's no way to stop this correction being applied again.