### PR TITLE
Pass `max_coeffs` through from `grism_prep()`

### DIFF
--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -3516,7 +3516,39 @@ def load_GroupFLT(field_root='j142724+334246', PREP_PATH='../Prep', force_ref=No
         return [grp]
 
 
-def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='../Extractions', ds9=None, refine_niter=3, gris_ref_filters=GRIS_REF_FILTERS, force_ref=None, files=None, split_by_grism=True, refine_poly_order=1, refine_fcontam=0.5, cpu_count=0, mask_mosaic_edges=False, prelim_mag_limit=25, refine_mag_limits=[18, 24], init_coeffs=[1.1, -0.5], grisms_to_process=None, pad=(64, 256), model_kwargs={'compute_size': True}, sep_background_kwargs=None, subtract_median_filter=False, median_filter_size=71, median_filter_central=10, second_pass_filtering=False, box_filter_sn=3, box_filter_width=3, median_mask_sn_threshold=None, median_mask_dilate=8, prelim_model_for_median=False, use_jwst_crds=False):
+def grism_prep(
+    field_root="j142724+334246",
+    PREP_PATH="../Prep",
+    EXTRACT_PATH="../Extractions",
+    ds9=None,
+    refine_niter=3,
+    gris_ref_filters=GRIS_REF_FILTERS,
+    force_ref=None,
+    files=None,
+    split_by_grism=True,
+    refine_poly_order=1,
+    refine_fcontam=0.5,
+    cpu_count=0,
+    mask_mosaic_edges=False,
+    prelim_mag_limit=25,
+    refine_mag_limits=[18, 24],
+    init_coeffs=[1.1, -0.5],
+    max_coeff=5.0,
+    grisms_to_process=None,
+    pad=(64, 256),
+    model_kwargs={"compute_size": True},
+    sep_background_kwargs=None,
+    subtract_median_filter=False,
+    median_filter_size=71,
+    median_filter_central=10,
+    second_pass_filtering=False,
+    box_filter_sn=3,
+    box_filter_width=3,
+    median_mask_sn_threshold=None,
+    median_mask_dilate=8,
+    prelim_model_for_median=False,
+    use_jwst_crds=False,
+):
     """
     Contamination model pipeline for grism exposures
     
@@ -3574,6 +3606,10 @@ def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='.
     
     init_coeffs : [float, float]
         Polynomial coefficients for the first simple model
+
+    max_coeff : float
+            Fit is considered bad when one of the coefficients is greater
+            than this value.  See `~grizli.multifit.GroupFLT.refine`.
     
     grisms_to_process : list, None
         Explicit list of grisms to process, otherwise will do all that are found
@@ -3770,7 +3806,7 @@ def grism_prep(field_root='j142724+334246', PREP_PATH='../Prep', EXTRACT_PATH='.
 
                 grp.refine_list(poly_order=refine_poly_order, 
                                 mag_limits=refine_mag_limits,
-                                max_coeff=5, ds9=ds9, verbose=True,
+                                max_coeff=max_coeff, ds9=ds9, verbose=True,
                                 fcontam=refine_i,
                                 wave=np.linspace(*grp.polyx[:2], 100)*1.e4)
         

--- a/grizli/pipeline/auto_script.py
+++ b/grizli/pipeline/auto_script.py
@@ -3590,6 +3590,7 @@ def grism_prep(
     refine_fcontam : float
         Factor multiplying the contamination model that is added to the variance of
         and extracted spectrum.
+
     cpu_count : int
         Multiprocessing, see `~grizli.multifit.GroupFLT.compute_full_model`.
     
@@ -3608,8 +3609,9 @@ def grism_prep(
         Polynomial coefficients for the first simple model
 
     max_coeff : float
-            Fit is considered bad when one of the coefficients is greater
-            than this value.  See `~grizli.multifit.GroupFLT.refine`.
+        Fit is considered bad when the polynomial contamination model returns a total
+        flux greater than `max_coeff` times the *observed* flux in the
+        direct image. See `~grizli.multifit.GroupFLT.refine`.
     
     grisms_to_process : list, None
         Explicit list of grisms to process, otherwise will do all that are found


### PR DESCRIPTION
A simple update to allow tuning of the maximum polynomial coefficients when refining the contamination model. From testing, max_coeff=5 can often be too large a deviation from the direct image if pixels are saturated, but this commit preserves the default behaviour for backwards compatibility.

Also reformatted the parameters for `grism_prep()` for better consistency with the current codestyle.