### PR TITLE
Check for valid pixels in beams

### DIFF
--- a/grizli/multifit.py
+++ b/grizli/multifit.py
@@ -6293,7 +6293,7 @@ class MultiBeam(GroupFitter):
         return pyfits.HDUList(p)
 
     def check_for_bad_PAs(
-        self, poly_order=1, chi2_threshold=1.5, fit_background=True, reinit=True
+        self, poly_order=1, chi2_threshold=1.5, fit_background=True, reinit=True, min_valid_pix=1,
     ):
         """
         Check for bad PAs based on chi-squared values
@@ -6312,6 +6312,10 @@ class MultiBeam(GroupFitter):
         reinit : bool
             Reinitialize the `~grizli.multifit.MultiBeam` object with thes
             beams that pass the threshold.
+
+        min_valid_pix : int
+            Minimum number of valid pixels (`beam.fit_mask == True`) in 2D
+            spectrum.
 
         Returns
         -------
@@ -6340,7 +6344,21 @@ class MultiBeam(GroupFitter):
             keep_dict[g] = []
 
             for pa in self.PA[g]:
-                beams = [self.beams[i] for i in self.PA[g][pa]]
+
+                beams = [
+                    self.beams[i]
+                    for i in self.PA[g][pa]
+                    if self.fit_mask[self.slices[i]].sum() > min_valid_pix
+                ]
+
+                if len(beams)==0:
+                    fit_log[g][pa] = {
+                        "chi2": 1e31,
+                        "DoF": 1,
+                        "chi_nu": 1e31,
+                    }
+                    continue
+
                 mb_i = MultiBeam(
                     beams,
                     fcontam=self.fcontam,
@@ -6356,7 +6374,7 @@ class MultiBeam(GroupFitter):
                         z=0, templates=poly_templates, fit_background=fit_background
                     )
                 except:
-                    chi2 = 1e30
+                    chi2 = 1e31
 
                 if False:
                     p_i = mb_i.template_at_z(
@@ -6385,11 +6403,23 @@ class MultiBeam(GroupFitter):
 
                 if fit_log[g][pa]["chinu_ratio"] < chi2_threshold:
                     keep_dict[g].append(pa)
-                    keep_beams.extend([self.beams[i] for i in self.PA[g][pa]])
+                    keep_beams.extend(
+                        [
+                            self.beams[i]
+                            for i in self.PA[g][pa]
+                            if self.fit_mask[self.slices[i]].sum() > min_valid_pix
+                        ]
+                    )
                 else:
                     has_bad = True
 
         if reinit:
+            if len(keep_beams)==0:
+                raise ValueError(
+                    f"No beams found with >{min_valid_pix} unmasked pixels. "
+                    "Ensure that `min_mask`, `min_sens`, `fcontam`, and `mask_resid` "
+                    "are all set to the correct values."
+                )
             self.beams = keep_beams
             self._parse_beams(psf=self.psf_param_dict is not None)
 


### PR DESCRIPTION
Check that all beams have at least 1 valid pixel when checking for bad PAs in a MultiBeam object. This can occur when fitting beams using a different combination of `min_sens`, `fcontam`, `min_mask`, and `mask_resid` than the beams were extracted with. 

If no valid pixels are present, then the NNLS fitter will crash the python interpreter attempting to fit a zero-dimensional array. This has already been fixed upstream in [`scipy>=1.18`](https://github.com/scipy/scipy/issues/24861), but that version is only 1 week old, and is unlikely to be used in all `grizli` installations for some time.