### PR TITLE
Numba fixes

### DIFF
--- a/grizli/model.py
+++ b/grizli/model.py
@@ -3494,7 +3494,7 @@ class GrismFLT(object):
                 )
 
                 ymin, ymax, y, xmin, xmax, x, area, segm_flux = out
-                if (area == 0) | ~np.isfinite(x) | ~np.isfinite(y):
+                if (area <= 0) | ~np.isfinite(x) | ~np.isfinite(y):
                     if verbose:
                         print("ID {0:d} not found in segmentation image".format(id))
                     return False

--- a/grizli/tests/test_cutils.py
+++ b/grizli/tests/test_cutils.py
@@ -14,13 +14,17 @@ INTERP_MODULES = [interp_numba]
 
 def test_cinterp():
     """
-    Simple interpolation
+    Simple interpolation.
+
+    Tests for correct extrapolation if arrays do not overlap.
     """
     xarr = np.array([0.0, 1.0, 2.0])
     yarr = np.array([0.0, 1.0, 0.0])
-    for base_module in INTERP_MODULES:
-        result = base_module.interp_c(np.array([0.5]), xarr, yarr)
-        assert np.allclose(result, 0.5)
+
+    for xp, expected in zip([-1.0, 0.5, 3.0],[0.0, 0.5, 0.0]):
+        for base_module in INTERP_MODULES:
+            result = base_module.interp_c(np.array([xp]), xarr, yarr)
+            assert np.allclose(result, expected)
 
 
 def test_cinterp_conserve():

--- a/grizli/tests/test_cutils.py
+++ b/grizli/tests/test_cutils.py
@@ -166,7 +166,11 @@ def test_disperse_c():
 
 def test_segmentation_limits():
     """
-    Accelerator function to calculate segmentation cutouts
+    Accelerator function to calculate segmentation cutouts.
+
+    Test for correct centre, area, flux with regular flux map, zero area
+    if object not in seg map, and finite area but negative flux if the
+    flux map is negative.
     """
     sh = (128, 128)
     x0 = (32, 38)
@@ -174,6 +178,8 @@ def test_segmentation_limits():
     yp, xp = np.indices(sh)
     
     flam = np.sqrt((xp - x0[0]) ** 2 + (yp - x0[1]) ** 2).astype(np.float32)
+    flam_all_neg = flam.copy() - 5.0
+    flam_part_neg = flam.copy() - 4.0
     
     Rsize = 5
     segm = (flam < Rsize).astype(np.float32)
@@ -182,6 +188,7 @@ def test_segmentation_limits():
 
     for disperse_module in DISPERSE_MODULES:
 
+        # Finite flux map: all values finite
         _ = disperse_module.compute_segmentation_limits(
             segm, 1.0, flam, np.array(sh, dtype=int)
         )
@@ -195,6 +202,7 @@ def test_segmentation_limits():
         assert area == int(segm.sum())
         assert np.allclose(tot_i, total_flux, rtol=1.0e-5)
 
+        # Not in seg_map: zero area, negative (error) flux
         _ = disperse_module.compute_segmentation_limits(
             segm, 2.0, flam, np.array(sh, dtype=int)
         )
@@ -202,3 +210,26 @@ def test_segmentation_limits():
         imin, imax, ic, jmin, jmax, jc, area, tot_i = _
         assert area == 0
         assert np.allclose(tot_i, -99.0, rtol=1.0e-5)
+
+        # All negative flux map: finite area, negative flux, nan centre
+        _ = disperse_module.compute_segmentation_limits(
+            segm, 1.0, flam_all_neg, np.array(sh, dtype=int)
+        )
+        imin, imax, ic, jmin, jmax, jc, area, tot_i = _
+
+        assert area == int(segm.sum())
+        assert np.allclose(tot_i, flam_all_neg[segm > 0].sum(), rtol=1.0e-5)
+        assert np.isnan(ic)
+        assert np.isnan(jc)
+
+        # Partially negative flux map: finite area, negative flux, finite centre
+        _ = disperse_module.compute_segmentation_limits(
+            segm, 1.0, flam_part_neg, np.array(sh, dtype=int)
+        )
+        imin, imax, ic, jmin, jmax, jc, area, tot_i = _
+
+        assert area == int(segm.sum())
+        assert np.allclose(tot_i, flam_part_neg[segm > 0].sum(), rtol=1.0e-5)
+
+        assert imin <= ic <= imax
+        assert jmin <= jc <= jmax

--- a/grizli/tests/test_cutils.py
+++ b/grizli/tests/test_cutils.py
@@ -25,18 +25,24 @@ def test_cinterp():
 
 def test_cinterp_conserve():
     """
-    Linear interpolation conserving the integral
+    Linear interpolation conserving the integral.
+
+    Tests for both interpolation to lower and higher resolution arrays.
     """
-    xarr = np.arange(1.0, 3.0, 0.0001)
-    yarr = (np.abs(xarr - 2.0) <= 0.1) * 1.0
 
-    np.random.seed(1)
-    xlr = np.random.rand(10) * 2 + 1
-    xlr.sort()
+    # assert False, f"{os.getenv("NUMBA_BOUNDSCHECK")=}"
+    rng = np.random.default_rng(1)
 
-    for base_module in INTERP_MODULES:
-        ylr = base_module.interp_conserve_c(xlr, xarr, yarr)
-        assert np.allclose(utils.trapz(ylr, xlr), utils.trapz(yarr, xarr))
+    for orig_len, new_len in zip([20000, 100],[10,101]):
+        xarr = np.linspace(1.0, 3.0, orig_len)
+        yarr = (np.abs(xarr - 2.0) <= 0.1) * 1.0
+
+        xlr = rng.random(new_len) * 2 + 1
+        xlr.sort()
+
+        for base_module in INTERP_MODULES:
+            ylr = base_module.interp_conserve_c(xlr, xarr, yarr)
+            assert np.allclose(utils.trapz(ylr, xlr), utils.trapz(yarr, xarr))
 
 
 def test_disperse_c():

--- a/grizli/utils_numba/disperse.py
+++ b/grizli/utils_numba/disperse.py
@@ -168,7 +168,7 @@ def compute_segmentation_limits(segm, seg_id, flam, shd):
                 continue
 
             area += 1
-            wht_ij = np.max([flam[i, j], 0.0])
+            wht_ij = max(flam[i, j], 0.0)
             inumer += i * wht_ij
             jnumer += j * wht_ij
             denom += wht_ij

--- a/grizli/utils_numba/disperse.py
+++ b/grizli/utils_numba/disperse.py
@@ -158,6 +158,9 @@ def compute_segmentation_limits(segm, seg_id, flam, shd):
     inumer = 0.0
     jnumer = 0.0
     flam_total = 0.0
+    denom = 0.0
+    ic = 0.0
+    jc = 0.0
 
     for i in range(shd[0]):
         for j in range(shd[1]):
@@ -165,10 +168,11 @@ def compute_segmentation_limits(segm, seg_id, flam, shd):
                 continue
 
             area += 1
-            wht_ij = flam[i, j]
+            wht_ij = np.max([flam[i, j], 0.0])
             inumer += i * wht_ij
             jnumer += j * wht_ij
-            flam_total += wht_ij
+            denom += wht_ij
+            flam_total += flam[i, j]
 
             if i < imin:
                 imin = i
@@ -182,15 +186,24 @@ def compute_segmentation_limits(segm, seg_id, flam, shd):
 
     ### No matched pixels
     if flam_total == 0:
+        denom = -1
         flam_total = -99
+
+    if denom <= 0.0:
+        ### No positive flux to calculate weighted centroid
+        ic = np.nan
+        jc = np.nan
+    else:
+        ic = inumer / denom
+        jc = jnumer / denom
 
     return (
         imin,
         imax,
-        inumer / flam_total,
+        ic,
         jmin,
         jmax,
-        jnumer / flam_total,
+        jc,
         area,
         flam_total,
     )

--- a/grizli/utils_numba/interp.py
+++ b/grizli/utils_numba/interp.py
@@ -188,12 +188,12 @@ def interp_conserve_c(x, xp, yp, left=0, right=0, integrate=0):
 
     for k in range(k, NTEMPL):
         xmk = xmid[k]
-        if xmk > xp[nxp - 1]:
-            break
-
         xmk1 = xmid[k + 1]
         ymk = ymid[k]
         ymk1 = ymid[k + 1]
+
+        if (xmk > xp[nxp - 1]) or (xmk1 > xp[nxp - 1]):
+            break
 
         numsum = 0.0
 

--- a/grizli/utils_numba/interp.py
+++ b/grizli/utils_numba/interp.py
@@ -182,7 +182,7 @@ def interp_conserve_c(x, xp, yp, left=0, right=0, integrate=0):
     k = 0
 
     tl0 = xp[0]
-    while xmid[k] < tl0:
+    while (xmid[k] < tl0) & (k < NTEMPL - 1):
         outy[k] = left
         k += 1
 

--- a/grizli/utils_numba/interp.py
+++ b/grizli/utils_numba/interp.py
@@ -78,7 +78,7 @@ def interp_c(x, xp, fp, extrapolate=0.0, assume_sorted=1):
     ### Handle left extrapolation
     xmin = xp[0]
     if assume_sorted == 1:
-        while x[j] < xmin:
+        while (x[j] < xmin) & (j < N - 1):
             f[j] = extrapolate
             j += 1
 
@@ -192,7 +192,7 @@ def interp_conserve_c(x, xp, yp, left=0, right=0, integrate=0):
         ymk = ymid[k]
         ymk1 = ymid[k + 1]
 
-        if (xmk > xp[nxp - 1]) or (xmk1 > xp[nxp - 1]):
+        if (xmk > xp[nxp - 1]) | (xmk1 > xp[nxp - 1]):
             break
 
         numsum = 0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,7 @@ test =
     pytest>=5.1
     flake8
     drizzlepac
+    pytest-env
 docs =
     sphinx
     sphinx-astropy
@@ -109,4 +110,6 @@ minversion = 5.0
 norecursedirs = build docs/_build
 testpaths =
     grizli/tests
-
+env =
+    NUMBA_BOUNDSCHECK = 1
+    NUMBA_DISABLE_JIT = 1


### PR DESCRIPTION
I've been running into a few low-level crashes when trying to set up and run grizli on a new server, which seems to be linked to newer versions of numpy/numba. There's no obvious deprecated functions that are to blame, but I had a look at the functions in `utils_numba` with jit compilation turned off and/or `boundscheck=True`, and there were a few cases of out-of-bounds array indexing.

- `interp_c`: if the interpolant array is shifted to the left of the original, and doesn't overlap with the original, the extrapolation loop continues beyond the end of the interpolant array. This shouldn't really happen, and probably indicates something wrong with the trace configuration, but it is possible if the centroid is shifted (see below).
- `interp_conserve_c`: The same problem as above. Additionally, if the new array is a higher resolution than the original, the midpoints can extend beyond the original array and cause another index error. This one is rare, but does seem to crop up occasionally in real data when deriving the (flattened) 2D sensitivity arrays.
- `compute_segmentation_limits`: This currently weights the centroid by the f_lam flux, regardless of the sign. If the detection image is not the same as the beam direct image (e.g. multiple filters stacked for detection), and the beam image is partially or fully negative (e.g. background oversubtraction, or poor flat-fielding), this can shift the centroid outside of the segmentation limits.

I've tried to fix all of these in `utils_numba/`, and can no longer reproduce any of the previous crashes I ran into. I've also expanded `test_cutils.py` to account for all of the above (admittedly niche) scenarios. The slight quirk here is that none of these _necessarily_ result in failing tests with the default jit compilation and `boundscheck=False`. I've therefore turned both of these off for running pytest, which might lead to a slight slowdown for these tests (at least on my laptop, the difference is negligible).