### PR TITLE
Propagate FWCPOS to BeamCutout

### DIFF
--- a/grizli/model.py
+++ b/grizli/model.py
@@ -2634,6 +2634,7 @@ class ImageData(object):
             pupil=self.pupil,
             module=self.module,
             process_jwst_header=False,
+            fwcpos=self.fwcpos
         )
 
         slice_obj.ref_photflam = self.ref_photflam


### PR DESCRIPTION
Another bug fix sorry - after running a field through the pipeline with #294 applied, I noticed that the filter wheel rotation wasn't being used in the individual object fits. Traced this back to `ImageData.get_slice()`, which doesn't currently copy the value over. 