### PR TITLE
Stability/Documentation Update to jwst_outliers module

### DIFF
--- a/docs/grizli/index.rst
+++ b/docs/grizli/index.rst
@@ -26,6 +26,9 @@ Utilities
 .. automodapi:: grizli.jwst_utils
     :no-inheritance-diagram:
 
+.. automodapi:: grizli.jwst_outliers
+    :no-inheritance-diagram:
+
 .. automodapi:: grizli.utils_numba.interp
     :no-inheritance-diagram:
 

--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -107,7 +107,7 @@ visit_prep_args: &prep_args
     drizzle_params: {}
     single_image_CRs: True
     run_jwst_outliers: False
-    jwst_outliers_kwargs: 
+    jwst_outlier_kwargs: 
         snr: "8.0 5.0"
         scale: "2.5 0.7"
         save_intermediate_results: False

--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -112,6 +112,7 @@ visit_prep_args: &prep_args
         scale: "2.5 0.7"
         save_intermediate_results: False
         in_memory: True
+    run_dual_outliers: False
     with_ctx_mask: True
     erode_ctx_single: 3
     run_tweak_align: True

--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -106,6 +106,12 @@ visit_prep_args: &prep_args
     skymethod: localmin
     drizzle_params: {}
     single_image_CRs: True
+    run_jwst_outliers: False
+    jwst_outliers_kwargs: 
+        snr: "8.0 5.0"
+        scale: "2.5 0.7"
+        save_intermediate_results: False
+        in_memory: True
     with_ctx_mask: True
     erode_ctx_single: 3
     run_tweak_align: True

--- a/grizli/data/auto_script_defaults.yml
+++ b/grizli/data/auto_script_defaults.yml
@@ -107,7 +107,7 @@ visit_prep_args: &prep_args
     drizzle_params: {}
     single_image_CRs: True
     run_jwst_outliers: False
-    jwst_outlier_kwargs: 
+    jwst_outliers_kwargs: 
         snr: "8.0 5.0"
         scale: "2.5 0.7"
         save_intermediate_results: False

--- a/grizli/jwst_outliers.py
+++ b/grizli/jwst_outliers.py
@@ -407,7 +407,7 @@ def run_rate_file_group(
 
                 # clear any existing DQ=16 and 4096 bits in file...
                 # like we did in dq model before
-                dq_data = dq_data & CLEAR_BITS
+                dq_data = dq_data & JWST_OUTLIER_CLEAR_MASK
 
                 # set grizli bit where bit=16 was set by this step
                 dq_data |= (

--- a/grizli/jwst_outliers.py
+++ b/grizli/jwst_outliers.py
@@ -315,7 +315,7 @@ def run_rate_file_group(
     rate_files,
     min_files=2,
     verbose=True,
-    jwst_outlier_kwargs=None,
+    jwst_outliers_kwargs=None,
 ):
     """
     Run JWST outlier detection for one group of rate files.
@@ -458,7 +458,7 @@ def do_jwst_outliers_step(
     group_by=("detector", "filter", "pupil", "shape"),
     clean=True,
     verbose=True,
-    jwst_outlier_kwargs=None,
+    jwst_outliers_kwargs=None,
 ):
     """
     Run JWST outlier detection for grouped files in a visit.
@@ -516,7 +516,7 @@ def do_jwst_outliers_step(
             groups[key],
             min_files=min_files,
             verbose=verbose,
-            jwst_outlier_kwargs=jwst_outlier_kwargs,
+            jwst_outliers_kwargs=jwst_outliers_kwargs,
         )
 
     if clean:

--- a/grizli/jwst_outliers.py
+++ b/grizli/jwst_outliers.py
@@ -315,7 +315,7 @@ def run_rate_file_group(
     rate_files,
     min_files=2,
     verbose=True,
-    jwst_outliers_kwargs=None,
+    jwst_outlier_kwargs=None,
 ):
     """
     Run JWST outlier detection for one group of rate files.
@@ -458,7 +458,7 @@ def do_jwst_outliers_step(
     group_by=("detector", "filter", "pupil", "shape"),
     clean=True,
     verbose=True,
-    jwst_outliers_kwargs=None,
+    jwst_outlier_kwargs=None,
 ):
     """
     Run JWST outlier detection for grouped files in a visit.
@@ -516,7 +516,7 @@ def do_jwst_outliers_step(
             groups[key],
             min_files=min_files,
             verbose=verbose,
-            jwst_outliers_kwargs=jwst_outliers_kwargs,
+            jwst_outlier_kwargs=jwst_outlier_kwargs,
         )
 
     if clean:

--- a/grizli/jwst_outliers.py
+++ b/grizli/jwst_outliers.py
@@ -7,9 +7,15 @@ import inspect
 
 import numpy as np
 from astropy.io import fits
+from astropy.stats import sigma_clipped_stats
 
 from grizli import jwst_utils
 from grizli import utils
+
+from jwst.datamodels import ModelContainer
+from jwst.outlier_detection.outlier_detection_step import (
+        OutlierDetectionStep,
+    )
 
 SCI = "SCI"
 ERR = "ERR"
@@ -135,46 +141,40 @@ def file_info(path):
     return info
 
 
-def get_mdrizsky(path):
-    """
-    Get the ``MDRIZSKY`` value from the science extension.
-
+def bkg_fallback_estimate(path):
+    """Scalar background estimate from the SCI extension.
+    
     Parameters
     ----------
-    path : str or pathlib.Path
-        Input FITS rate file.
+    prep_dir : str or pathlib.Path
+        Directory to clean.
 
     Returns
     -------
-    mdrizsky : float
-        Sky level recorded in the ``SCI`` header.
+    bkg_ : float
+        Estimate of background level using 
+        sigma-clipped median. 
     """
+
     with fits.open(path, memmap=False) as hdul:
-        header = hdul[SCI].header
-        mdrizsky = float(header["MDRIZSKY"])
+        data = hdul["SCI"].data
+        #no nans
+        mask = ~np.isfinite(data)
 
-    return mdrizsky
+        #only consider "good" pixels
+        if "DQ" in hdul:
+            mask |= hdul["DQ"].data != 0
 
+        _, background, _ = sigma_clipped_stats(
+            data,
+            mask=mask,
+            sigma=3,
+            maxiters=5,
+        )
 
-def rate_to_cal_path(path):
-    """
-    Convert a ``*_rate.fits`` filename to the temporary ``*_cal.fits`` name.
+    bkg_ = float(background)
 
-    Parameters
-    ----------
-    path : str or pathlib.Path
-        Input rate filename.
-
-    Returns
-    -------
-    cal_path : pathlib.Path
-        Temporary cal filename.
-    """
-    path = Path(path)
-    cal_path = path.with_name(path.name.replace("_rate.fits", "_cal.fits"))
-
-    return cal_path
-
+    return bkg_
 
 def cleanup_files(prep_dir=".", verbose=True):
     """
@@ -237,7 +237,7 @@ def make_model(path, index):
     # only want to make new DQ flags and write them explicitly below.
     model = jwst_utils.match_gwcs_to_sip(
         str(path),
-        overwrite=False,
+        overwrite=False, 
     )
 
     # Name the files for the JWST pipeline.
@@ -253,10 +253,28 @@ def make_model(path, index):
         np.asarray(model.dq, dtype=np.uint32) & JWST_OUTLIER_CLEAR_MASK
     ).astype(model.dq.dtype, copy=False)
 
-    # The science extension should still have sky level in it.  Set the
-    # background metadata from the prior AstroDrizzle MDRIZSKY value.
+    try: 
+        # The science extension should still have sky level in it.  Set the
+        # background metadata from the prior AstroDrizzle MDRIZSKY value.
+
+        #fail loudly if not in header.
+        mdrizsky = float(fits.getheader(path, "SCI")["MDRIZSKY"])
+
+        log(f"MDRIZSKY keyword found in header, " \
+            f"using {mdrizsky:.2f} for background level.")
+        
+        sky_ = mdrizsky
+
+    except:
+        sky_ = bkg_fallback_estimate(path)
+
+        log(f"No MDRIZSKY keyword in header, " \
+            f"falling back to sigma-clipped median" \
+            f" value of {sky_:.2f}" \
+            f" from ``SCI`` extension.")
+
     model.meta.background.subtracted = False
-    model.meta.background.level = get_mdrizsky(path)
+    model.meta.background.level = sky_
 
     return model, old_dq
 
@@ -281,10 +299,6 @@ def run_jwst_outliers(models, step_kwargs={"snr": "8.0 5.0",
     outlier_dq_arrays : list
         Updated DQ arrays from the outlier step, converted to ``uint32``.
     """
-    from jwst.datamodels import ModelContainer
-    from jwst.outlier_detection.outlier_detection_step import (
-        OutlierDetectionStep,
-    )
 
     container = ModelContainer(open_models=False)
     for model in models:
@@ -338,7 +352,7 @@ def run_rate_file_group(
         Print log messages if ``True``.
 
     jwst_outliers_kwargs : dict or None
-        Extra keyword arguments passed to ``OutlierDetectionStep``.  Explicit
+        Extra keyword arguments passed to ``OutlierDetectionStep``.  
         ``snr`` and ``scale`` values override ``driz_cr_snr`` and
         ``driz_cr_scale``.
 
@@ -360,7 +374,11 @@ def run_rate_file_group(
 
     log("running JWST outlier DQ on %d rate files." % len(paths), verbose)
 
-    cal_paths = [rate_to_cal_path(path) for path in paths]
+    cal_paths = []
+    for p in paths:
+        p = Path(p)
+        cp_ = p.with_name(p.name.replace("_rate.fits", "_cal.fits"))
+        cal_paths.append(cp_)
 
     models = []
     old_dq = []
@@ -413,25 +431,20 @@ def run_rate_file_group(
                 dq_data |= (
                     step_outliers.astype(np.uint32) * GRIZLI_OUTLIER_BIT
                 )
-                # update dq array in rate file
+                # in-place update dq array in rate file
                 hdul[DQ].data[...] = dq_data.astype(
                     hdul[DQ].data.dtype,
-                    copy=False,
+                    copy=False, 
                 )
                 # save
                 hdul.flush()
 
-            log(
-                "updated %s: mapped DQ=%d to DQ=%d; %d outlier pixels flagged. (%.3f%%)"
-                % (
-                    paths[i].name,
-                    JWST_OUTLIER_BIT,
-                    GRIZLI_OUTLIER_BIT,
-                    int(np.count_nonzero(step_outliers)),
-                    float(np.round(100*np.count_nonzero(step_outliers) / npix, 3))
-                ),
-                verbose,
-            )
+            log(f"updated {paths[i].name}: "
+                f"mapped DQ={JWST_OUTLIER_BIT} to DQ={GRIZLI_OUTLIER_BIT}; "
+                f"{int(np.count_nonzero(step_outliers))} "
+                f"outlier pixels flagged. "
+                f"({np.count_nonzero(step_outliers) / npix:.3%})"
+                )
 
     except Exception:
         log("JWST outlier DQ failed; traceback follows.", verbose)
@@ -497,8 +510,8 @@ def do_jwst_outliers_step(
 
     frame = inspect.currentframe()
     utils.log_function_arguments(
-                    utils.LOGFILE, frame, "jwst_outliers.do_jwst_outliers_step"
-                    )
+        utils.LOGFILE, frame, "jwst_outliers.do_jwst_outliers_step"
+        )
     
     prep_dir = pathfix(visit["files"][0]).parent
 

--- a/grizli/jwst_outliers.py
+++ b/grizli/jwst_outliers.py
@@ -17,8 +17,10 @@ DQ = "DQ"
 
 JWST_OUTLIER_BIT = 16
 GRIZLI_OUTLIER_BIT = 4096
-#pre-make a mask to unset DQ=16 to save linespace...
-JWST_OUTLIER_CLEAR_MASK = np.bitwise_not(np.uint32(JWST_OUTLIER_BIT))
+
+CLEAR_BITS = JWST_OUTLIER_BIT + GRIZLI_OUTLIER_BIT
+#pre-make a mask to unset DQ=16+4096 to save linespace...
+JWST_OUTLIER_CLEAR_MASK = np.bitwise_not(np.uint32(CLEAR_BITS))
 
 #grizli modifies key names so shold check for both
 ORIGINAL_KEYS = {
@@ -245,7 +247,7 @@ def make_model(path, index):
     # Keep the input DQ array before letting the JWST step add DQ=16.
     old_dq = model.dq.copy()
 
-    # Clear any existing JWST OUTLIER bit before the step runs.  The step can
+    # Clear any existing 16+4096 bits before the step runs.  The step can
     # set bit 16 again, and this module maps that mask to Grizli DQ=4096.
     model.dq[...] = (
         np.asarray(model.dq, dtype=np.uint32) & JWST_OUTLIER_CLEAR_MASK
@@ -399,31 +401,17 @@ def run_rate_file_group(
             # get boolean where bit was set
             step_outliers = (result_dq & JWST_OUTLIER_BIT) > 0
 
-            # Find pixels that already had JWST DQ=16 before the step.
-            # returns boolean where bit was set
-            old_step_outliers = (old_dq[i] & JWST_OUTLIER_BIT) > 0
-
-            # Keep every pixel flagged by either the old or new DQ=16 mask.
-            # this gives true where bit=16 was set (before or after)
-            grizli_outliers = step_outliers | old_step_outliers
-
-            # Find pixels that already had Grizli DQ=4096 before the step.
-            old_grizli_outliers = (old_dq[i] & GRIZLI_OUTLIER_BIT) > 0
-
-            # Find pixels that are newly getting Grizli DQ=4096 here.
-            # grab ones that are new for accounting in log
-            new_grizli_outliers = grizli_outliers & ~old_grizli_outliers
-
-
             with fits.open(cal_path, mode="update", memmap=False) as hdul:
                 #pull out DQ array that is in rate file...
                 dq_data = np.asarray(hdul[DQ].data, dtype=np.uint32)
-                # clear any existing DQ=16 bits in file...
-                dq_data = dq_data & JWST_OUTLIER_CLEAR_MASK
 
-                # set grizli bit where bit=16 was set (before or after)
+                # clear any existing DQ=16 and 4096 bits in file...
+                # like we did in dq model before
+                dq_data = dq_data & CLEAR_BITS
+
+                # set grizli bit where bit=16 was set by this step
                 dq_data |= (
-                    grizli_outliers.astype(np.uint32) * GRIZLI_OUTLIER_BIT
+                    step_outliers.astype(np.uint32) * GRIZLI_OUTLIER_BIT
                 )
                 # update dq array in rate file
                 hdul[DQ].data[...] = dq_data.astype(
@@ -434,7 +422,7 @@ def run_rate_file_group(
                 hdul.flush()
 
             log(
-                "updated %s: mapped DQ=%d to DQ=%d; %d outlier pixels detected. (%.3f%%)"
+                "updated %s: mapped DQ=%d to DQ=%d; %d outlier pixels flagged. (%.3f%%)"
                 % (
                     paths[i].name,
                     JWST_OUTLIER_BIT,
@@ -535,3 +523,4 @@ def do_jwst_outliers_step(
         cleanup_files(prep_dir, verbose=verbose)
 
     return 1
+

--- a/grizli/jwst_outliers.py
+++ b/grizli/jwst_outliers.py
@@ -1,113 +1,360 @@
-import numpy as np
+"""Run JWST outlier detection on Grizli-prepped rate files."""
+
+import traceback
 from collections import defaultdict
 from pathlib import Path
 
+import numpy as np
 from astropy.io import fits
-from grizli import utils
+
 from grizli import jwst_utils
+from grizli import utils
 
 SCI = "SCI"
 ERR = "ERR"
 DQ = "DQ"
-ORIGINAL_KEYS = {"TELESCOP": "OTELESCO", "INSTRUME": "OINSTRUM", "DETECTOR": "ODETECTO", "EXP_TYPE": "OEXP_TYP"}
+
+JWST_OUTLIER_BIT = 16
+GRIZLI_OUTLIER_BIT = 4096
+#pre-make a mask to unset DQ=16 to save linespace...
+JWST_OUTLIER_CLEAR_MASK = np.bitwise_not(np.uint32(JWST_OUTLIER_BIT))
+
+#grizli modifies key names so shold check for both
+ORIGINAL_KEYS = {
+    "TELESCOP": "OTELESCO",
+    "INSTRUME": "OINSTRUM",
+    "DETECTOR": "ODETECTO",
+    "EXP_TYPE": "OEXP_TYP",
+}
+
 
 def log(msg, verbose=True):
-    utils.log_comment(utils.LOGFILE, "# jwst_rate_outliers: " + str(msg), verbose=verbose, show_date=True)
+    """
+    Write a JWST outlier message to the Grizli log.
+
+    Parameters
+    ----------
+    msg : object
+        Message to write to the log.
+
+    verbose : bool
+        Print the message if ``True``.
+
+    Returns
+    -------
+    None
+    """
+    utils.log_comment(
+        utils.LOGFILE,
+        "# jwst_rate_outliers: " + str(msg),
+        verbose=verbose,
+        show_date=True,
+    )
+
 
 def pathfix(path):
+    """
+    Return an absolute ``Path`` with user expansion applied.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Input path.
+
+    Returns
+    -------
+    path : pathlib.Path
+        Absolute path.
+    """
     path = Path(path).expanduser()
     if not path.is_absolute():
         path = Path.cwd() / path
+
     return path
 
+
 def hval(header, key, default=""):
+    """
+    Get a FITS header value, checking Grizli original-key aliases first.
+
+    Parameters
+    ----------
+    header : astropy.io.fits.Header
+        FITS header to query.
+
+    key : str
+        Header keyword.
+
+    default : object
+        Default value returned if ``key`` is not found.
+
+    Returns
+    -------
+    value : object
+        Header value.
+    """
     key = key.upper()
-    return header.get(ORIGINAL_KEYS.get(key, "O" + key[:7]), header.get(key, default))
+    original_key = ORIGINAL_KEYS.get(key, "O" + key[:7])
+    fallback = header.get(key, default)
+    value = header.get(original_key, fallback)
+
+    return value
+
 
 def file_info(path):
+    """
+    Read grouping metadata from a rate file.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Input FITS rate file.
+
+    Returns
+    -------
+    info : dict
+        Dictionary with instrument, detector, filter, pupil, exposure type,
+        and science-array shape.
+    """
     with fits.open(path, memmap=False) as hdul:
-        h = hdul[0].header
-        return {
-            "instrument": str(hval(h, "INSTRUME")).strip().upper(),
-            "detector": str(hval(h, "DETECTOR")).strip().upper(),
-            "filter": str(hval(h, "FILTER")).strip().upper(),
-            "pupil": str(hval(h, "PUPIL")).strip().upper(),
-            "exp_type": str(hval(h, "EXP_TYPE", "NRC_IMAGE")).strip().upper(),
+        header = hdul[0].header
+        info = {
+            "instrument": str(hval(header, "INSTRUME")).strip().upper(),
+            "detector": str(hval(header, "DETECTOR")).strip().upper(),
+            "filter": str(hval(header, "FILTER")).strip().upper(),
+            "pupil": str(hval(header, "PUPIL")).strip().upper(),
+            "exp_type": str(
+                hval(header, "EXP_TYPE", "NRC_IMAGE")
+            ).strip().upper(),
             "shape": tuple(hdul[SCI].data.shape),
         }
-    
+
+    return info
+
+
 def get_mdrizsky(path):
+    """
+    Get the ``MDRIZSKY`` value from the science extension.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Input FITS rate file.
+
+    Returns
+    -------
+    mdrizsky : float
+        Sky level recorded in the ``SCI`` header.
+    """
     with fits.open(path, memmap=False) as hdul:
-        h = hdul["SCI"].header
-        return float(h["MDRIZSKY"])
+        header = hdul[SCI].header
+        mdrizsky = float(header["MDRIZSKY"])
+
+    return mdrizsky
+
 
 def rate_to_cal_path(path):
-    path = Path(path)
-    return path.with_name(path.name.replace("_rate.fits", "_cal.fits"))
+    """
+    Convert a ``*_rate.fits`` filename to the temporary ``*_cal.fits`` name.
 
-def cleanup_files(prep_dir=".", verbose=True): #delete *blot.fits and *median.fits files which seem to not be getting removed...
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Input rate filename.
+
+    Returns
+    -------
+    cal_path : pathlib.Path
+        Temporary cal filename.
+    """
+    path = Path(path)
+    cal_path = path.with_name(path.name.replace("_rate.fits", "_cal.fits"))
+
+    return cal_path
+
+
+def cleanup_files(prep_dir=".", verbose=True):
+    """
+    Delete JWST outlier intermediate files from a prep directory.
+
+    Parameters
+    ----------
+    prep_dir : str or pathlib.Path
+        Directory to clean.
+
+    verbose : bool
+        Print log messages if ``True``.
+
+    Returns
+    -------
+    removed : int
+        Number of files removed.
+    """
     prep_dir = pathfix(prep_dir)
     removed = 0
+
     for pattern in ("*blot.fits", "*median.fits"):
         for path in prep_dir.glob(pattern):
             if path.is_file():
                 log(f"removing intermediate file {path.name}", verbose)
-                path.unlink() #.unlink() is same as delete 
+                path.unlink()
                 removed += 1
 
-    log(f"removed {removed} JWST outlier intermediate files from {prep_dir}", verbose)
+    log(
+        f"removed {removed} JWST outlier intermediate files from {prep_dir}",
+        verbose,
+    )
 
     return removed
 
+
 def make_model(path, index):
     """
-    Make ImageModel from grizli-prepped rate file w/ dither naming /bkg stuff for outlier rejection. 
+    Make an ImageModel from a Grizli-prepped rate file.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Input FITS rate file.
+
+    index : int
+        One-indexed dither number used to set ``meta.group_id``.
+
+    Returns
+    -------
+    model : jwst.datamodels.ImageModel
+        Data model passed to ``OutlierDetectionStep``.
+
+    old_dq : ndarray
+        Copy of the input DQ array before clearing JWST outlier bit 16.
     """
     path = Path(path)
 
+    # Do not rewrite the Grizli-prepped rate file here.  At this stage we
+    # only want to make new DQ flags and write them explicitly below.
     model = jwst_utils.match_gwcs_to_sip(
         str(path),
-        overwrite=False)   # do not rewrite the Grizli-prepped rate file here, we only want to make new DQ flags at this stage and flush those
+        overwrite=False,
+    )
 
-    # name the files for jwst-pipeline (still needs this?)
+    # Name the files for the JWST pipeline.
     model.meta.filename = path.name
     model.meta.group_id = f"dither{index:03d}"
 
-    # bkg stuff - not sure is used/matters but set it just in case. 
-    model.meta.background.subtracted = False #sci extension still has sky-level in it I think
-    model.meta.background.level = get_mdrizsky(path) #use mdrizsky value from prior astrodrizzle run, shoudl be in SCI header
+    # Keep the input DQ array before letting the JWST step add DQ=16.
+    old_dq = model.dq.copy()
 
-    return model, model.dq.copy()
+    # Clear any existing JWST OUTLIER bit before the step runs.  The step can
+    # set bit 16 again, and this module maps that mask to Grizli DQ=4096.
+    model.dq[...] = (
+        np.asarray(model.dq, dtype=np.uint32) & JWST_OUTLIER_CLEAR_MASK
+    ).astype(model.dq.dtype, copy=False)
 
-def run_jwst_outliers(models, driz_cr_snr, driz_cr_scale):
+    # The science extension should still have sky level in it.  Set the
+    # background metadata from the prior AstroDrizzle MDRIZSKY value.
+    model.meta.background.subtracted = False
+    model.meta.background.level = get_mdrizsky(path)
+
+    return model, old_dq
+
+
+def run_jwst_outliers(models, **kwargs):
+    """
+    Run JWST ``OutlierDetectionStep`` on a list of data models.
+
+    Parameters
+    ----------
+    models : list
+        JWST data models made from Grizli-prepped rate files.
+
+    **kwargs : dict
+        Keyword arguments passed directly to ``OutlierDetectionStep``.
+
+    Returns
+    -------
+    outlier_dq_arrays : list
+        Updated DQ arrays from the outlier step, converted to ``uint32``.
+    """
     from jwst.datamodels import ModelContainer
-    from jwst.outlier_detection.outlier_detection_step import OutlierDetectionStep
+    from jwst.outlier_detection.outlier_detection_step import (
+        OutlierDetectionStep,
+    )
 
-    container = ModelContainer(open_models=False) #make "container" object
-    for m in models:
-        container.append(m) #add the DataModels made from the grizli-processed rate files into the container.
+    container = ModelContainer(open_models=False)
+    for model in models:
+        container.append(model)
 
-    result = OutlierDetectionStep( #run the rejection step w/ all defualt params except for the snr and scale param
-        snr=driz_cr_snr,
-        scale=driz_cr_scale, 
-        save_intermediate_results=False,       
-        in_memory=True).process(container)
-    
-    output_list_of_updated_dq_arrays = [ #make list of output dq arrays that have the new bits set. 
-        np.asarray(result[i].dq, dtype=np.uint32).copy()
-        for i in range(len(models))
-    ]
+    step = OutlierDetectionStep(**kwargs)
+    result = step.process(container)
 
-    return output_list_of_updated_dq_arrays
+    # make list of output dq arrays that have the new bits set.
+    try:
+        # jwst=1.13
+        outlier_dq_arrays = [ 
+            np.asarray(result[i].dq, dtype=np.uint32).copy()
+            for i in range(len(models))
+        ]
+    except TypeError:
+        # jwst=1.16
+        # datamodel orig. dq attr should be updated too?
+        outlier_dq_arrays = [ 
+            np.asarray(m.dq, dtype=np.uint32).copy()
+            for m in models
+        ]
+
+    return outlier_dq_arrays
+
 
 def run_rate_file_group_outlier_dq(
     rate_files,
     driz_cr_snr="8.0 5.0",
     driz_cr_scale="2.5 0.7",
     min_files=2,
-    verbose=True):
-    
-    paths = [pathfix(f) for f in rate_files]
+    verbose=True,
+    jwst_outliers_kwargs=None,
+):
+    """
+    Run JWST outlier detection for one group of rate files.
+
+    Parameters
+    ----------
+    rate_files : list
+        Rate files to process together.
+
+    driz_cr_snr : str
+        Default ``snr`` value passed to ``OutlierDetectionStep``.
+
+    driz_cr_scale : str
+        Default ``scale`` value passed to ``OutlierDetectionStep``.
+
+    min_files : int
+        Minimum number of files needed to run the outlier step.
+
+    verbose : bool
+        Print log messages if ``True``.
+
+    jwst_outliers_kwargs : dict or None
+        Extra keyword arguments passed to ``OutlierDetectionStep``.  Explicit
+        ``snr`` and ``scale`` values override ``driz_cr_snr`` and
+        ``driz_cr_scale``.
+
+    Returns
+    -------
+    status : int
+        ``1`` if the group was processed and ``0`` if it was skipped.
+    """
+    if jwst_outliers_kwargs is None:
+        step_kwargs = {}
+    else:
+        step_kwargs = dict(jwst_outliers_kwargs)
+
+    if "snr" not in step_kwargs:
+        step_kwargs["snr"] = driz_cr_snr
+
+    if "scale" not in step_kwargs:
+        step_kwargs["scale"] = driz_cr_scale
+
+    paths = [pathfix(rate_file) for rate_file in rate_files]
 
     if len(paths) < min_files:
         log("only %d file(s); skipping" % len(paths), verbose)
@@ -115,60 +362,106 @@ def run_rate_file_group_outlier_dq(
 
     log("running JWST outlier DQ on %d rate files." % len(paths), verbose)
 
-    cal_paths = [rate_to_cal_path(p) for p in paths]
+    cal_paths = [rate_to_cal_path(path) for path in paths]
 
     models = []
     old_dq = []
     renamed = []
 
     try:
-        #Rename *_rate.fits -> *_cal.fits (gets around weird bug where jwst pipeline deletes rate files at the end?)
+        # Rename *_rate.fits to *_cal.fits so the JWST pipeline 
+        # doesnt delete the *rate files when done w. O.R. step ...
         for rate_path, cal_path in zip(paths, cal_paths):
             log(f"rename {rate_path.name} -> {cal_path.name}", verbose)
             rate_path.rename(cal_path)
             renamed.append((rate_path, cal_path))
 
-        # Run outlier detection on the temporary "_cal".fits files...
+        # Run outlier detection on the temporary *_cal.fits files.
+        # Loop over each temporary *_cal.fits file.
         for i, cal_path in enumerate(cal_paths, 1):
+            # Make the JWST data model and copy the starting DQ array.
             model, dq = make_model(cal_path, i)
 
-            model.meta.filename = cal_path.name
-            model.meta.group_id = f"dither{i:03d}"
-
+            # Add this model to the list passed to OutlierDetectionStep.
             models.append(model)
+
+            # Add the starting DQ array to the list used for comparisons.
             old_dq.append(dq)
 
-        result_dq_arrays = run_jwst_outliers(
-            models,
-            driz_cr_snr,
-            driz_cr_scale,
-        )
+        # Run OutlierDetectionStep and return one updated DQ array per model.
+        result_dq_arrays = run_jwst_outliers(models, **step_kwargs)
 
-        #write new dq bits... (might already be done but just to make sure)
+        # Loop over each file and map JWST DQ=16 to Grizli DQ=4096.
         for i, cal_path in enumerate(cal_paths):
+            # Select the updated DQ array for this file.
             result_dq = result_dq_arrays[i]
-            added = result_dq & ~old_dq[i]
+
+            # Find pixels where OutlierDetectionStep set JWST DQ=16.
+            # get boolean where bit was set
+            step_outliers = (result_dq & JWST_OUTLIER_BIT) > 0
+
+            # Find pixels that already had JWST DQ=16 before the step.
+            # returns boolean where bit was set
+            old_step_outliers = (old_dq[i] & JWST_OUTLIER_BIT) > 0
+
+            # Keep every pixel flagged by either the old or new DQ=16 mask.
+            # this gives true where bit=16 was set (before or after)
+            grizli_outliers = step_outliers | old_step_outliers
+
+            # Find pixels that already had Grizli DQ=4096 before the step.
+            old_grizli_outliers = (old_dq[i] & GRIZLI_OUTLIER_BIT) > 0
+
+            # Find pixels that are newly getting Grizli DQ=4096 here.
+            # grab ones that are new for accounting in log
+            new_grizli_outliers = grizli_outliers & ~old_grizli_outliers
 
             with fits.open(cal_path, mode="update", memmap=False) as hdul:
-                new_dq = np.asarray(hdul[DQ].data, dtype=np.uint32) | added #use "or" operator to keep old bits too...
-                hdul[DQ].data[...] = new_dq.astype(
+                #pull out DQ array that is in rate file...
+                dq_data = np.asarray(hdul[DQ].data, dtype=np.uint32)
+                # clear any existing DQ=16 bits in file...
+                dq_data = dq_data & JWST_OUTLIER_CLEAR_MASK
+
+                # set grizli bit where bit=16 was set (before or after)
+                dq_data |= (
+                    grizli_outliers.astype(np.uint32) * GRIZLI_OUTLIER_BIT
+                )
+                # update dq array in rate file
+                hdul[DQ].data[...] = dq_data.astype(
                     hdul[DQ].data.dtype,
                     copy=False,
                 )
-                hdul.flush() #save
+                # save
+                hdul.flush()
 
-            log("updated %s: added %d new bits to DQ-array." % (paths[i].name, int(np.count_nonzero(added != 0))), verbose)
+            log(
+                "updated %s: mapped DQ=%d to DQ=%d; %d new pixels."
+                % (
+                    paths[i].name,
+                    JWST_OUTLIER_BIT,
+                    GRIZLI_OUTLIER_BIT,
+                    int(np.count_nonzero(new_grizli_outliers)),
+                ),
+                verbose,
+            )
+
+    except Exception:
+        log("JWST outlier DQ failed; traceback follows.", verbose)
+        # throw error msg to grizli log if needed...
+        utils.log_exception(utils.LOGFILE, traceback)
+        raise
 
     finally:
-        # Close sll the models before renaming files back...
+        # Close all models before renaming files back.
         for model in models:
             model.close()
 
-        #Rename back at end
+        # Rename files back at the end.
         for rate_path, cal_path in reversed(renamed):
-                cal_path.rename(rate_path)
+            log(f"rename back {cal_path.name} -> {rate_path.name}", verbose)
+            cal_path.rename(rate_path)
 
     return 1
+
 
 def run_nircam_rate_outliers(
     visit,
@@ -177,28 +470,65 @@ def run_nircam_rate_outliers(
     min_files=2,
     group_by=("detector", "filter", "pupil", "shape"),
     clean=True,
-    verbose=True): 
+    verbose=True,
+    jwst_outliers_kwargs=None,
+):
+    """
+    Run JWST outlier detection for grouped files in a visit.
 
+    Parameters
+    ----------
+    visit : dict
+        Visit dictionary with a ``files`` entry containing rate filenames.
+
+    driz_cr_snr : str
+        Default ``snr`` value passed to ``OutlierDetectionStep``.
+
+    driz_cr_scale : str
+        Default ``scale`` value passed to ``OutlierDetectionStep``.
+
+    min_files : int
+        Minimum number of files needed in a group to run the outlier step.
+
+    group_by : tuple
+        Metadata keys used to group files before running the outlier step.
+
+    clean : bool
+        Delete JWST intermediate files after processing if ``True``.
+
+    verbose : bool
+        Print log messages if ``True``.
+
+    jwst_outliers_kwargs : dict or None
+        Extra keyword arguments passed to ``OutlierDetectionStep``.
+
+    Returns
+    -------
+    status : int
+        ``1`` after processing all groups.
+    """
     prep_dir = pathfix(visit["files"][0]).parent
 
     groups = defaultdict(list)
     for filename in visit["files"]:
         path = pathfix(filename)
         info = file_info(path)
-        key = tuple(info[k] for k in group_by)
+        key = tuple(info[item] for item in group_by)
         groups[key].append(path)
 
     for key in sorted(groups, key=str):
         log("group %s: %d files" % (key, len(groups[key])), verbose)
 
-        _ = run_rate_file_group_outlier_dq( #run the main-processing function
+        run_rate_file_group_outlier_dq(
             groups[key],
             driz_cr_snr=driz_cr_snr,
             driz_cr_scale=driz_cr_scale,
             min_files=min_files,
-            verbose=verbose)
-        
+            verbose=verbose,
+            jwst_outliers_kwargs=jwst_outliers_kwargs,
+        )
+
     if clean:
-        cleanup_files(prep_dir, verbose=verbose) #delete stuff we dont need
+        cleanup_files(prep_dir, verbose=verbose)
 
     return 1

--- a/grizli/jwst_outliers.py
+++ b/grizli/jwst_outliers.py
@@ -9,8 +9,8 @@ import numpy as np
 from astropy.io import fits
 from astropy.stats import sigma_clipped_stats
 
-from grizli import jwst_utils
-from grizli import utils
+from . import jwst_utils
+from . import utils
 
 from jwst.datamodels import ModelContainer
 from jwst.outlier_detection.outlier_detection_step import (

--- a/grizli/jwst_outliers.py
+++ b/grizli/jwst_outliers.py
@@ -9,13 +9,13 @@ import numpy as np
 from astropy.io import fits
 from astropy.stats import sigma_clipped_stats
 
-from . import jwst_utils
-from . import utils
-
 from jwst.datamodels import ModelContainer
 from jwst.outlier_detection.outlier_detection_step import (
         OutlierDetectionStep,
     )
+
+from . import jwst_utils
+from . import utils
 
 SCI = "SCI"
 ERR = "ERR"

--- a/grizli/jwst_outliers.py
+++ b/grizli/jwst_outliers.py
@@ -3,6 +3,7 @@
 import traceback
 from collections import defaultdict
 from pathlib import Path
+import inspect
 
 import numpy as np
 from astropy.io import fits
@@ -258,7 +259,10 @@ def make_model(path, index):
     return model, old_dq
 
 
-def run_jwst_outliers(models, **kwargs):
+def run_jwst_outliers(models, step_kwargs={"snr": "8.0 5.0", 
+                        "scale": "2.5 0.7",
+                        "save_intermediate_results": False, 
+                        "in_memory": False}):
     """
     Run JWST ``OutlierDetectionStep`` on a list of data models.
 
@@ -284,7 +288,7 @@ def run_jwst_outliers(models, **kwargs):
     for model in models:
         container.append(model)
 
-    step = OutlierDetectionStep(**kwargs)
+    step = OutlierDetectionStep(**step_kwargs)
     result = step.process(container)
 
     # make list of output dq arrays that have the new bits set.
@@ -305,10 +309,8 @@ def run_jwst_outliers(models, **kwargs):
     return outlier_dq_arrays
 
 
-def run_rate_file_group_outlier_dq(
+def run_rate_file_group(
     rate_files,
-    driz_cr_snr="8.0 5.0",
-    driz_cr_scale="2.5 0.7",
     min_files=2,
     verbose=True,
     jwst_outliers_kwargs=None,
@@ -348,12 +350,6 @@ def run_rate_file_group_outlier_dq(
     else:
         step_kwargs = dict(jwst_outliers_kwargs)
 
-    if "snr" not in step_kwargs:
-        step_kwargs["snr"] = driz_cr_snr
-
-    if "scale" not in step_kwargs:
-        step_kwargs["scale"] = driz_cr_scale
-
     paths = [pathfix(rate_file) for rate_file in rate_files]
 
     if len(paths) < min_files:
@@ -389,12 +385,15 @@ def run_rate_file_group_outlier_dq(
             old_dq.append(dq)
 
         # Run OutlierDetectionStep and return one updated DQ array per model.
-        result_dq_arrays = run_jwst_outliers(models, **step_kwargs)
+        result_dq_arrays = run_jwst_outliers(models, step_kwargs=step_kwargs)
 
         # Loop over each file and map JWST DQ=16 to Grizli DQ=4096.
         for i, cal_path in enumerate(cal_paths):
             # Select the updated DQ array for this file.
             result_dq = result_dq_arrays[i]
+
+            npixx, npixy = result_dq.shape[0], result_dq.shape[1]
+            npix = npixx * npixy
 
             # Find pixels where OutlierDetectionStep set JWST DQ=16.
             # get boolean where bit was set
@@ -415,6 +414,7 @@ def run_rate_file_group_outlier_dq(
             # grab ones that are new for accounting in log
             new_grizli_outliers = grizli_outliers & ~old_grizli_outliers
 
+
             with fits.open(cal_path, mode="update", memmap=False) as hdul:
                 #pull out DQ array that is in rate file...
                 dq_data = np.asarray(hdul[DQ].data, dtype=np.uint32)
@@ -434,12 +434,13 @@ def run_rate_file_group_outlier_dq(
                 hdul.flush()
 
             log(
-                "updated %s: mapped DQ=%d to DQ=%d; %d new pixels."
+                "updated %s: mapped DQ=%d to DQ=%d; %d outlier pixels detected. (%.3f%%)"
                 % (
                     paths[i].name,
                     JWST_OUTLIER_BIT,
                     GRIZLI_OUTLIER_BIT,
-                    int(np.count_nonzero(new_grizli_outliers)),
+                    int(np.count_nonzero(step_outliers)),
+                    float(np.round(100*np.count_nonzero(step_outliers) / npix, 3))
                 ),
                 verbose,
             )
@@ -463,10 +464,8 @@ def run_rate_file_group_outlier_dq(
     return 1
 
 
-def run_nircam_rate_outliers(
+def do_jwst_outliers_step(
     visit,
-    driz_cr_snr="8.0 5.0",
-    driz_cr_scale="2.5 0.7",
     min_files=2,
     group_by=("detector", "filter", "pupil", "shape"),
     clean=True,
@@ -507,6 +506,12 @@ def run_nircam_rate_outliers(
     status : int
         ``1`` after processing all groups.
     """
+
+    frame = inspect.currentframe()
+    utils.log_function_arguments(
+                    utils.LOGFILE, frame, "jwst_outliers.do_jwst_outliers_step"
+                    )
+    
     prep_dir = pathfix(visit["files"][0]).parent
 
     groups = defaultdict(list)
@@ -519,10 +524,8 @@ def run_nircam_rate_outliers(
     for key in sorted(groups, key=str):
         log("group %s: %d files" % (key, len(groups[key])), verbose)
 
-        run_rate_file_group_outlier_dq(
+        run_rate_file_group(
             groups[key],
-            driz_cr_snr=driz_cr_snr,
-            driz_cr_scale=driz_cr_scale,
             min_files=min_files,
             verbose=verbose,
             jwst_outliers_kwargs=jwst_outliers_kwargs,

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -34,6 +34,12 @@ except ImportError:
     jwst = None
     print("`import jwst` failed so JWST processing will not work!")
 
+try:
+    from . import jwst_outliers
+except ImportError:
+    print("`import jwst_outliers` failed so JWST outlier rejection will not work!")
+    jwst_outliers = None
+
 from . import utils
 from . import model
 from . import GRIZLI_PATH

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -5293,6 +5293,7 @@ def process_direct_grism_visit(
     write_ctx=False,
     run_jwst_outliers=False,
     jwst_outliers_kwargs={},
+    run_dual_outliers=False,
 ):
     """
     Full processing of a direct (+grism) image visit.
@@ -6107,6 +6108,76 @@ def process_direct_grism_visit(
                     skysub=True,
                     skymethod=skymethod,
                     resetbits=4096,
+                    final_bits=bits,
+                    driz_sep_bits=bits,
+                    preserve=False,
+                    driz_cr_snr=driz_cr_snr,
+                    driz_cr_scale=driz_cr_scale,
+                    driz_cr_grow=driz_cr_grow,
+                    build=False,
+                    final_wht_type="IVM",
+                    gain=_gain,
+                    rdnoise=_rdnoise,
+                    static=static_mask,
+                    **drizzle_params,
+                )
+        if (run_dual_outliers) and (run_jwst_outliers_):
+            # Second drizzle with aligned wcs, refined CR-rejection params
+            # tuned for WFC3/IR
+            logstr = "# {0}: Dual Outliers -- " \
+                "Running AstroDrizzle() Secondary Step.".format(direct["product"])
+            utils.log_comment(utils.LOGFILE, logstr, verbose=True, show_date=False)
+        
+            logstr = "# {0}: Second Drizzle".format(direct["product"])
+            utils.log_comment(utils.LOGFILE, logstr, verbose=True, show_date=True)
+
+            if len(direct["files"]) == 1:
+                #don't reset, just add new DQ bits. 
+                #not efficient, but is
+                #useful for assocs w. really big dithers?
+                AstroDrizzle(
+                    direct["files"],
+                    output=direct["product"],
+                    clean=True,
+                    final_pixfrac=0.8,
+                    context=False,
+                    resetbits=0, 
+                    final_bits=bits,
+                    driz_sep_bits=bits,
+                    preserve=False,
+                    driz_cr_snr=driz_cr_snr,
+                    driz_cr_scale=driz_cr_scale,
+                    driz_separate=False,
+                    driz_sep_wcs=False,
+                    median=False,
+                    blot=False,
+                    driz_cr=False,
+                    driz_cr_corr=False,
+                    build=False,
+                    final_wht_type="IVM",
+                    gain=_gain,
+                    rdnoise=_rdnoise,
+                    static=False,
+                    **drizzle_params,
+                )
+            else:
+                if "par" in direct["product"]:
+                    pixfrac = 1.0
+                else:
+                    pixfrac = 0.8
+
+                #don't reset, just add new
+                #not efficient, but is
+                #useful for assocs w. really big dithers?
+                AstroDrizzle(
+                    direct["files"],
+                    output=direct["product"],
+                    clean=True,
+                    final_pixfrac=pixfrac,
+                    context=(isACS | isWFPC2),
+                    skysub=True,
+                    skymethod=skymethod,
+                    resetbits=0, 
                     final_bits=bits,
                     driz_sep_bits=bits,
                     preserve=False,

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -9691,4 +9691,3 @@ def check_isJWST(infile=""):
             isJWST = False
 
     return isJWST
-

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -5292,7 +5292,7 @@ def process_direct_grism_visit(
     do_pure_parallel_wcs=True,
     write_ctx=False,
     run_jwst_outliers=False,
-    jwst_outliers_kwargs={},
+    jwst_outlier_kwargs={},
 ):
     """
     Full processing of a direct (+grism) image visit.

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -5292,6 +5292,7 @@ def process_direct_grism_visit(
     do_pure_parallel_wcs=True,
     write_ctx=False,
     run_jwst_outliers=False,
+    jwst_outliers_kwargs={},
 ):
     """
     Full processing of a direct (+grism) image visit.
@@ -6026,20 +6027,31 @@ def process_direct_grism_visit(
                 im[0].header["MJD-OBS"] = im[0].header["EXPSTART"]
                 im.flush()
 
-        #Option to run outliers for JWST using `jwst.outlier_detection.OutlierDetectionStep()`
-        if (isJWST) and (run_jwst_outliers):
+        #run outliers for JWST using `jwst.outlier_detection.OutlierDetectionStep()` - ALR added
+        if (isJWST) and (run_jwst_outliers) and (jwst_outliers is not None):
+
+            # set defaults here too just in case
+            if "snr" not in jwst_outliers_kwargs:
+                jwst_outliers_kwargs["snr"] = driz_cr_snr
+
+            if "scale" not in jwst_outliers_kwargs:
+                jwst_outliers_kwargs["scale"] = driz_cr_scale
+
+            if "in_memory" not in jwst_outliers_kwargs:
+                jwst_outliers_kwargs["in_memory"] = True
+
+            if "save_intermediate_results" not in jwst_outliers_kwargs:
+                jwst_outliers_kwargs["save_intermediate_results"] = False
+
             try:
-                from grizli import jwst_outliers
                 jwst_outliers.run_nircam_rate_outliers(
                         direct,
-                        driz_cr_snr=driz_cr_snr, #same ones defined above seem to work best w. jwst-pipeline too?
-                        driz_cr_scale=driz_cr_scale,
-                        min_files=2,
-                        verbose=True,
+                        **jwst_outliers_kwargs
                         )
             except:
                 logstr = "JWST Outlier Detection Failed. Skipping..."
                 utils.log_comment(utils.LOGFILE, logstr, verbose=True, show_date=True)
+                utils.log_exception(utils.LOGFILE, traceback)
 
         # Second drizzle with aligned wcs, refined CR-rejection params
         # tuned for WFC3/IR

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -5292,7 +5292,7 @@ def process_direct_grism_visit(
     do_pure_parallel_wcs=True,
     write_ctx=False,
     run_jwst_outliers=False,
-    jwst_outlier_kwargs={},
+    jwst_outliers_kwargs={},
 ):
     """
     Full processing of a direct (+grism) image visit.
@@ -6033,22 +6033,22 @@ def process_direct_grism_visit(
 
         if run_jwst_outliers_:
             # make sure important defualts are set.
-            if "snr" not in jwst_outlier_kwargs:
+            if "snr" not in jwst_outliers_kwargs:
                 jwst_outliers_kwargs["snr"] = driz_cr_snr
 
-            if "scale" not in jwst_outlier_kwargs:
+            if "scale" not in jwst_outliers_kwargs:
                 jwst_outliers_kwargs["scale"] = driz_cr_scale
 
-            if "in_memory" not in jwst_outlier_kwargs:
+            if "in_memory" not in jwst_outliers_kwargs:
                 jwst_outliers_kwargs["in_memory"] = True
 
-            if "save_intermediate_results" not in jwst_outlier_kwargs:
+            if "save_intermediate_results" not in jwst_outliers_kwargs:
                 jwst_outliers_kwargs["save_intermediate_results"] = False
 
             try:
                 jwst_outliers.do_jwst_outliers_step(
                         direct,
-                        jwst_outliers_kwargs=jwst_outlier_kwargs,
+                        jwst_outliers_kwargs=jwst_outliers_kwargs,
                         )
             except:
                 utils.log_exception(utils.LOGFILE, traceback)

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -6030,7 +6030,7 @@ def process_direct_grism_visit(
         #run outliers for JWST using `jwst.outlier_detection.OutlierDetectionStep()` - ALR added
         if (isJWST) and (run_jwst_outliers) and (jwst_outliers is not None):
 
-            # set defaults here too just in case
+            # set !! important !! defaults here too just in case
             if "snr" not in jwst_outliers_kwargs:
                 jwst_outliers_kwargs["snr"] = driz_cr_snr
 
@@ -6044,9 +6044,9 @@ def process_direct_grism_visit(
                 jwst_outliers_kwargs["save_intermediate_results"] = False
 
             try:
-                jwst_outliers.run_nircam_rate_outliers(
+                jwst_outliers.do_jwst_outliers_step(
                         direct,
-                        **jwst_outliers_kwargs
+                        jwst_outliers_kwargs=jwst_outliers_kwargs,
                         )
             except:
                 logstr = "JWST Outlier Detection Failed. Skipping..."

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -6027,91 +6027,99 @@ def process_direct_grism_visit(
                 im[0].header["MJD-OBS"] = im[0].header["EXPSTART"]
                 im.flush()
 
-        #run outliers for JWST using `jwst.outlier_detection.OutlierDetectionStep()` - ALR added
-        if (isJWST) and (run_jwst_outliers) and (jwst_outliers is not None):
+        # Optionally run outliers for JWST using 
+        # `jwst.outlier_detection.OutlierDetectionStep()`
+        run_jwst_outliers_ = (isJWST) and (run_jwst_outliers) and (jwst_outliers is not None)
 
-            # set !! important !! defaults here too just in case
-            if "snr" not in jwst_outliers_kwargs:
+        if run_jwst_outliers_:
+            # make sure important defualts are set.
+            if "snr" not in jwst_outlier_kwargs:
                 jwst_outliers_kwargs["snr"] = driz_cr_snr
 
-            if "scale" not in jwst_outliers_kwargs:
+            if "scale" not in jwst_outlier_kwargs:
                 jwst_outliers_kwargs["scale"] = driz_cr_scale
 
-            if "in_memory" not in jwst_outliers_kwargs:
+            if "in_memory" not in jwst_outlier_kwargs:
                 jwst_outliers_kwargs["in_memory"] = True
 
-            if "save_intermediate_results" not in jwst_outliers_kwargs:
+            if "save_intermediate_results" not in jwst_outlier_kwargs:
                 jwst_outliers_kwargs["save_intermediate_results"] = False
 
             try:
                 jwst_outliers.do_jwst_outliers_step(
                         direct,
-                        jwst_outliers_kwargs=jwst_outliers_kwargs,
+                        jwst_outliers_kwargs=jwst_outlier_kwargs,
                         )
             except:
+                utils.log_exception(utils.LOGFILE, traceback)
                 logstr = "JWST Outlier Detection Failed. Skipping..."
                 utils.log_comment(utils.LOGFILE, logstr, verbose=True, show_date=True)
-                utils.log_exception(utils.LOGFILE, traceback)
 
-        # Second drizzle with aligned wcs, refined CR-rejection params
-        # tuned for WFC3/IR
-        logstr = "# {0}: Second Drizzle".format(direct["product"])
-        utils.log_comment(utils.LOGFILE, logstr, verbose=True, show_date=True)
+                # if fail, default to AstroDrizzle() below. 
+                run_jwst_outliers_ = False
 
-        if len(direct["files"]) == 1:
-            AstroDrizzle(
-                direct["files"],
-                output=direct["product"],
-                clean=True,
-                final_pixfrac=0.8,
-                context=False,
-                resetbits=4096,
-                final_bits=bits,
-                driz_sep_bits=bits,
-                preserve=False,
-                driz_cr_snr=driz_cr_snr,
-                driz_cr_scale=driz_cr_scale,
-                driz_separate=False,
-                driz_sep_wcs=False,
-                median=False,
-                blot=False,
-                driz_cr=False,
-                driz_cr_corr=False,
-                build=False,
-                final_wht_type="IVM",
-                gain=_gain,
-                rdnoise=_rdnoise,
-                static=False,
-                **drizzle_params,
-            )
-        else:
-            if "par" in direct["product"]:
-                pixfrac = 1.0
+        if not run_jwst_outliers_:
+            # default to normal Second drizzle step using AstroDrizzle() 
+
+            # Second drizzle with aligned wcs, refined CR-rejection params
+            # tuned for WFC3/IR
+            logstr = "# {0}: Second Drizzle".format(direct["product"])
+            utils.log_comment(utils.LOGFILE, logstr, verbose=True, show_date=True)
+
+            if len(direct["files"]) == 1:
+                AstroDrizzle(
+                    direct["files"],
+                    output=direct["product"],
+                    clean=True,
+                    final_pixfrac=0.8,
+                    context=False,
+                    resetbits=4096,
+                    final_bits=bits,
+                    driz_sep_bits=bits,
+                    preserve=False,
+                    driz_cr_snr=driz_cr_snr,
+                    driz_cr_scale=driz_cr_scale,
+                    driz_separate=False,
+                    driz_sep_wcs=False,
+                    median=False,
+                    blot=False,
+                    driz_cr=False,
+                    driz_cr_corr=False,
+                    build=False,
+                    final_wht_type="IVM",
+                    gain=_gain,
+                    rdnoise=_rdnoise,
+                    static=False,
+                    **drizzle_params,
+                )
             else:
-                pixfrac = 0.8
+                if "par" in direct["product"]:
+                    pixfrac = 1.0
+                else:
+                    pixfrac = 0.8
 
-            AstroDrizzle(
-                direct["files"],
-                output=direct["product"],
-                clean=True,
-                final_pixfrac=pixfrac,
-                context=(isACS | isWFPC2),
-                skysub=True,
-                skymethod=skymethod,
-                resetbits=4096,
-                final_bits=bits,
-                driz_sep_bits=bits,
-                preserve=False,
-                driz_cr_snr=driz_cr_snr,
-                driz_cr_scale=driz_cr_scale,
-                driz_cr_grow=driz_cr_grow,
-                build=False,
-                final_wht_type="IVM",
-                gain=_gain,
-                rdnoise=_rdnoise,
-                static=static_mask,
-                **drizzle_params,
-            )
+                AstroDrizzle(
+                    direct["files"],
+                    output=direct["product"],
+                    clean=True,
+                    final_pixfrac=pixfrac,
+                    context=(isACS | isWFPC2),
+                    skysub=True,
+                    skymethod=skymethod,
+                    resetbits=4096,
+                    final_bits=bits,
+                    driz_sep_bits=bits,
+                    preserve=False,
+                    driz_cr_snr=driz_cr_snr,
+                    driz_cr_scale=driz_cr_scale,
+                    driz_cr_grow=driz_cr_grow,
+                    build=False,
+                    final_wht_type="IVM",
+                    gain=_gain,
+                    rdnoise=_rdnoise,
+                    static=static_mask,
+                    **drizzle_params,
+                )
 
         # Flag areas of ACS images covered by a single image, where
         # CRs aren't appropriately masked

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -9691,3 +9691,4 @@ def check_isJWST(infile=""):
             isJWST = False
 
     return isJWST
+

--- a/grizli/prep.py
+++ b/grizli/prep.py
@@ -5453,6 +5453,20 @@ def process_direct_grism_visit(
     write_ctx : bool
         Write context.
 
+    run_jwst_outliers: bool
+        Flag to run the `jwst_outliers` script.
+        If `True` but the step fails, falls back to 
+        AstroDrizzle
+
+    jwst_outliers_kwargs: dict
+        Arguments to pass to `jwst.OutlierDetectionStep`
+
+    run_dual_outliers: bool
+        Flag to also run `AstroDrizzle` outlier flagging 
+        after `jwst` step. Only proceeds to `AstroDrizzle`
+        upon (1) successful completion of the `jwst` step, 
+        and `run_dual_outliers=True`
+
     Returns
     -------
     status : bool


### PR DESCRIPTION
Update to jwst_outliers module. Building on https://github.com/gbrammer/grizli/pull/301, and response to https://github.com/gbrammer/grizli/issues/302

Major changes include:

- stability update so module should now work with `jwst==1.13.x` and also `jwst==1.16.x`, but may be incompatible with `jwst==2.y.x`
- Added option for keyword arguments to be passed to `OutlierDetectionStep`, which may be set in the `prep_args{}` dictionary. Default parameters are set in `.../data/auto_script_defaults.yml`

- Updated flow of `process_direct_grism_visit` so that if `run_jwst_outliers=True`, then the second drizzle rejectoin step using `AstroDrizzle` is skipped. However, If the jwst outlier rejectoin fails for any reason, the `AstroDrizzle` is run instead. The logic for HST associations should be unaffected. 

- Updated the DQ bit which is set by `OutlierDetectionStep` to be DQ=4096, rather than the step defaults. Also updated the logic to clear any pre-existing DQ=4096 or DQ=16 bits before the rejection is run. 

- codestyle and documentation updates. 
